### PR TITLE
doc: document native TLS termination support

### DIFF
--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -22,6 +22,7 @@ SYNOPSIS
 
 varnishd
     [-a [name=][listen_address[,PROTO|,option=value,...]]
+    [-A cfgfile]
     [-b [host[:port]|path]]
     [-C]
     [-d]
@@ -78,8 +79,9 @@ Basic options
 
   Valid options depend on the acceptor type, see below.
 
-  PROTO can be "HTTP" (the default) or "PROXY".  Both version 1
-  and 2 of the proxy protocol can be used.
+  PROTO can be "HTTP" (the default), "PROXY" or "HTTPS".  Both version 1
+  and 2 of the proxy protocol can be used.  When "HTTPS" is specified,
+  the listener will accept TLS connections (see also ``-A`` below).
 
   Multiple -a arguments are allowed.
 
@@ -110,6 +112,20 @@ Basic options
   permissions of the socket file -- use names for user and group, and
   a 3-digit octal value for mode. These sub-arguments do not apply to
   abstract sockets.
+
+-A cfgfile
+
+  Load TLS configuration from the specified file. The file defines listen
+  endpoints and their TLS settings (certificates, protocols, ciphers).
+
+  When ``-A`` is used, Varnish terminates TLS natively without needing an
+  external TLS proxy.
+
+  Certificates can also be managed at runtime using the ``tls.cert.*``
+  family of CLI commands (see :ref:`varnish-cli(7)`).
+
+  An alternative to ``-A`` is to use ``-a`` with the ``HTTPS`` protocol,
+  for example ``-a :443,HTTPS``, and then load certificates via the CLI.
 
 -b <[host[:port]|path]>
 

--- a/doc/sphinx/tutorial/introduction.rst
+++ b/doc/sphinx/tutorial/introduction.rst
@@ -14,19 +14,20 @@ Varnish, and it is a pretty apt metafor::
 
        ┌─────────┐
        │ browser │
-       └─────────┘                                            ┌─────────┐
-                  \                                          ┌─────────┐│
-       ┌─────┐     ╔═════════╗    ┌─────┐    ┌─────────┐    ┌─────────┐│┘
-       │ app │ --- ║ Network ║ -- │ TLS │ -- │ Varnish │ -- │ Backend │┘
-       └─────┘     ╚═════════╝    └─────┘    └─────────┘    └─────────┘
+       └─────────┘                                     ┌─────────┐
+                  \                                   ┌─────────┐│
+       ┌─────┐     ╔═════════╗    ┌─────────┐        ┌─────────┐│┘
+       │ app │ --- ║ Network ║ -- │ Varnish │ ------ │ Backend │┘
+       └─────┘     ╚═════════╝    └─────────┘        └─────────┘
                    /
        ┌────────────┐
        │ API-client │
        └────────────┘
 
-The top layer of the sandwich, 'TLS' is responsible for handling
-the TLS ("https") encryption, which means it must have access to
-the cryptographic certificate which authenticates your website.
+Since version 9.0, Varnish handles TLS ("https") termination
+natively using the ``-A`` flag or by specifying ``https`` as the
+protocol on a listen address. In earlier versions, a separate TLS
+proxy was required in front of Varnish.
 
 The bottom layer of the sandwich are your webservers, CDNs,
 API-servers, business backend systems and all the other sources for

--- a/doc/sphinx/users-guide/command-line.rst
+++ b/doc/sphinx/users-guide/command-line.rst
@@ -8,10 +8,10 @@
 Required command line arguments
 -------------------------------
 
-There only one command line argument you have to provide when starting Varnish,
-which is '-b' for where the backend server can be contacted.
+There is only one command line argument you have to provide when starting
+Varnish, which is '-b' for where the backend server can be contacted.
 
-'-a' is another argument which is likely to require adjustment.
+'-a' and '-A' are other arguments which are likely to require adjustment.
 
 If you have installed Varnish through using a provided operating system bound package,
 you will find the startup options here:
@@ -46,6 +46,22 @@ Here are some examples::
         -a uds=/my/path,PROXY,mode=666
         -a @abstract_socket
 
+To accept HTTPS traffic, use the ``HTTPS`` protocol::
+
+	-a :443,HTTPS
+
+Certificates are then managed at runtime using ``varnishadm tls.*`` commands.
+
+'-A' *cfgfile*
+^^^^^^^^^^^^^^
+
+The '-A' argument loads TLS configuration from a file, which defines listen
+endpoints and their TLS settings. This is an alternative to using '-a' with the
+``HTTPS`` protocol::
+
+	-A /etc/varnish/tls.conf
+
+See :ref:`varnishd(1)` for more details.
 
 '-f' *VCL-file* or '-b' *backend*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/sphinx/users-guide/esi.rst
+++ b/doc/sphinx/users-guide/esi.rst
@@ -169,10 +169,14 @@ ESI includes with HTTPS protocol
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If ESI:include tags specify HTTPS protocol, it will be ignored
-by default, because Varnish has no way to fetch it with encryption.
-If you want Varnish to fetch them like it does anything else, set::
+by default. If you want Varnish to treat ``https://`` ESI includes
+the same as ``http://``, set::
 
    param.set feature +esi_ignore_https
+
+Note that this strips the scheme and fetches the include over the
+backend connection as configured in VCL (which may or may not use TLS,
+depending on your backend configuration).
 
 ESI on partial responses (206)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx/users-guide/vcl-backends.rst
+++ b/doc/sphinx/users-guide/vcl-backends.rst
@@ -201,6 +201,13 @@ Varnish running on the same server/namespace can then use the
 The ``.authority`` attribute can be used to specify the `SNI`_ for the
 connection if it differs from ``.host``.
 
+.. note::
+
+   This proxy-based approach is useful when you need fine-grained control
+   over backend TLS settings per destination. For *client-side* TLS
+   termination (accepting HTTPS from clients), see the ``-A`` and
+   ``-a :port,HTTPS`` options documented in :ref:`varnishd(1)`.
+
 
 .. _users-guide-advanced_backend_servers-directors:
 

--- a/doc/sphinx/whats-new/changes-9.0.rst
+++ b/doc/sphinx/whats-new/changes-9.0.rst
@@ -17,8 +17,31 @@ merged, may be found in the `change log`_.
 varnishd
 ========
 
+Native TLS termination
+~~~~~~~~~~~~~~~~~~~~~~
+
+Varnish Cache 9.0 introduces native TLS termination support. This is a
+significant change: previous versions required an external TLS proxy in front
+of Varnish to handle HTTPS traffic.
+
+TLS can be configured in two ways:
+
+* Using a TLS configuration file::
+
+    varnishd -A /path/to/tls.conf
+
+* Using the ``https`` protocol on an accept address::
+
+    varnishd -a :443,https
+
+Certificates can also be managed at runtime using ``varnishadm tls.*``
+commands.
+
+With TLS enabled, the ``ReqStart`` VSL tag now includes a fourth field
+indicating whether ``http`` or ``https`` was used by the client.
+
 Other changes in varnishd
-~~~~~==~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Varnish Extensions (VEXTs) can now be loaded by specifying their basename as
 ``-E<name>``. When ``<name>`` is not a path (does not contain ``/``), a search


### PR DESCRIPTION
This update covers the introduction of native TLS termination, a major feature in Varnish 9.0 that removes the requirement for an external TLS proxy for HTTPS traffic.

Changes include:
- Documentation for the new -A command line argument to load TLS configuration files.
- Updates to the -a argument to support the HTTPS protocol.
- Information on runtime certificate management via varnishadm tls.* commands.
- Updated release notes for 9.0 and ESI documentation clarifications.
- Added notes to distinguish between native client-side TLS and existing backend TLS configurations.
- Update to the ReqStart VSL tag documentation reflecting the new protocol field.

closes: #33