### PR TITLE
vtc: stabilize s00006

### DIFF
--- a/bin/vinyltest/tests/s00006.vtc
+++ b/bin/vinyltest/tests/s00006.vtc
@@ -19,7 +19,7 @@ client c1 {
 	txreq -url "/"
 	rxresp
 	expect resp.status == 200
-	expect resp.http.Age == 0
+	expect resp.http.Age <= 1
 
 	delay 0.3
 


### PR DESCRIPTION
CI is sometimes too damn slow for us to observe a zero Age header after the .8s delay.