### PR TITLE
vtc-bisect: Accept a dirty working copy and varnishtest options

### DIFF
--- a/tools/vtc-bisect.sh
+++ b/tools/vtc-bisect.sh
@@ -53,8 +53,9 @@ usage() {
 
 	Environment variables:
 
-	CONFIGURE_OPTS : additional options for the configure script
-	MAKE_OPTS      : additional options for make(1) executions
+	CONFIGURE_OPTS   : additional options for the configure script
+	MAKE_OPTS        : additional options for make(1) executions
+	VARNISHTEST_OPTS : additional options for varnishtest executions
 
 	When <file> is empty or missing, bisect.vtc is expected to be found
 	at the root of the git repository. The current source tree is used
@@ -78,6 +79,8 @@ build() {
 }
 
 run() {
+	set +e
+
 	if build
 	then
 		# ignore unfortunate build-time modifications of srcdir
@@ -87,12 +90,10 @@ run() {
 		exit 125
 	fi
 
-	if [ -n "$INVERSE" ]
-	then
-		! bin/varnishtest/varnishtest -i "$VTC_FILE"
-	else
-		bin/varnishtest/varnishtest -i "$VTC_FILE"
-	fi
+	bin/varnishtest/varnishtest -i ${VARNISHTEST_OPTS:-} -- "$VTC_FILE"
+	TEST_RESULT=$?
+
+	test "$TEST_RESULT" ${INVERSE:+!}= 0
 	exit $?
 }
 

--- a/tools/vtc-bisect.sh
+++ b/tools/vtc-bisect.sh
@@ -158,7 +158,8 @@ test -n "$BISECT_GOOD" || BISECT_GOOD=$(git describe --abbrev=0 "$BISECT_BAD")
 # bisect mode
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
-readonly TMP_DIR=$(mktemp -d)
+TMP_DIR=$(mktemp -d)
+readonly TMP_DIR
 
 trap 'rm -rf $TMP_DIR' EXIT
 

--- a/tools/vtc-bisect.sh
+++ b/tools/vtc-bisect.sh
@@ -66,9 +66,19 @@ usage() {
 	This is useful to track a bug that was fixed without being noticed.
 
 	This script is expected to run from the root of the git repository
-	as well.
+	as well. The working copy may be dirty, in which case it will be
+	stashed and reapplied at each step, but it may prevent git-bisect
+	from checking a commit out if the dirty diff conflicts.
 	EOF
 	exit $#
+}
+
+stash() {
+	if $BISECT_DIRTY
+	then
+		git stash push -q
+		git stash apply -q
+	fi
 }
 
 build() {
@@ -78,20 +88,27 @@ build() {
 	}
 }
 
+clean() {
+	# ignore unfortunate build-time modifications of srcdir
+	git checkout -- .
+	$BISECT_DIRTY && git stash pop -q
+}
+
 run() {
 	set +e
 
-	if build
+	stash
+
+	if ! build
 	then
-		# ignore unfortunate build-time modifications of srcdir
-		git checkout -- .
-	else
-		git checkout -- .
-		exit 125
+		clean
+		exit 125 # tell git-bisect this commit cannot be tested
 	fi
 
 	bin/varnishtest/varnishtest -i ${VARNISHTEST_OPTS:-} -- "$VTC_FILE"
 	TEST_RESULT=$?
+
+	clean
 
 	test "$TEST_RESULT" ${INVERSE:+!}= 0
 	exit $?
@@ -99,6 +116,7 @@ run() {
 
 BISECT_GOOD=
 BISECT_BAD=
+BISECT_DIRTY=true
 MAKE_JOBS=
 INVERSE=
 RUN_MODE=false
@@ -125,6 +143,12 @@ test $# -eq 1 && VTC_FILE=$1
 BISECT_BAD=${BISECT_BAD:-HEAD}
 MAKE_JOBS=${MAKE_JOBS:-8}
 VTC_FILE=${VTC_FILE:-bisect.vtc}
+
+if git diff --quiet && git diff --quiet --cached
+then
+	# Unknown files are ignored on purpose, it would catch bisect.vtc
+	BISECT_DIRTY=false
+fi
 
 # run mode short circuit
 "$RUN_MODE" && run

--- a/tools/vtc-bisect.sh
+++ b/tools/vtc-bisect.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2019, 2021 Varnish Software AS
+# Copyright (c) 2019-2026 Varnish Software AS
 # All rights reserved.
 #
 # Author: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>


### PR DESCRIPTION
In order to track down an accidental bug fix and get rid of a workaround, I ended up needing these changes.

First, I needed to pass options to `varnishtest` because the test case introduced with the workaround was not reliable, and some stress (for example with `-n100 -j32`) was needed to make sure `git-bisect` wouldn't be misled. Eventually I rewrote the test case to be more reliable, but that is beyond the point.

Second, in order to verify when the bug fix was introduced, I needed to get rid of the workaround for the commit range. Starting git-bisect with a dirty working copy (with the workaround undone) turned out to work better (read, without conflicts) than trying to apply a patch at each step.

The result was a very reliable and repeatable bug fix hunt.