### PR TITLE
vmod_std: Add fallback value to std.getenv()

### DIFF
--- a/vmod/tests/std_b00012.vtc
+++ b/vmod/tests/std_b00012.vtc
@@ -15,6 +15,12 @@ varnish v1 -vcl {
 		set resp.http.X-FOO = std.getenv("FOO");
 		set resp.http.X-PATH = std.getenv("PATH");
 		set resp.http.X-unset = std.getenv(req.http.unset);
+		if (std.getenv("doesnotexist")) {
+			set resp.http.X-eval = "true";
+		} else {
+			set resp.http.X-eval = "false";
+		}
+		set resp.http.X-default = std.getenv("doesnotexist", default="def-val");
 	}
 } -start
 
@@ -24,4 +30,6 @@ client c1 {
 	expect resp.http.X-FOO == "BAR BAZ"
 	expect resp.http.X-PATH ~ "^/"
 	expect resp.http.X-unset == ""
+	expect resp.http.X-eval == "false"
+	expect resp.http.X-default == "def-val"
 } -run

--- a/vmod/vmod_std.c
+++ b/vmod/vmod_std.c
@@ -259,12 +259,18 @@ vmod_strstr(VRT_CTX, VCL_STRING s1, VCL_STRING s2)
 }
 
 VCL_STRING v_matchproto_(td_std_getenv)
-vmod_getenv(VRT_CTX, VCL_STRING name)
+vmod_getenv(VRT_CTX, VCL_STRING name, VCL_STRING def)
 {
+	const char *val;
+
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (name == NULL || *name == '\0')
 		return (NULL);
-	return (getenv(name));
+
+	val = getenv(name);
+	if (val == NULL)
+		return (def);
+	return (val);
 }
 
 VCL_VOID v_matchproto_(td_std_late_100_continue)

--- a/vmod/vmod_std.vcc
+++ b/vmod/vmod_std.vcc
@@ -497,7 +497,7 @@ $Function BOOL syntax(REAL)
 
 Returns ``true`` if VCL version is at least *REAL*.
 
-$Function STRING getenv(STRING name)
+$Function STRING getenv(STRING name, STRING default = 0)
 
 Return environment variable *name* or the empty string. See `getenv(3)`.
 


### PR DESCRIPTION
Adds a fallback argument to `std.getenv()` that is returned when the env variable is not defined, defaults to `NULL` to be backward compatible.

Refs: [vinyl-cache/vinyl-cache#4527](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/issues/4527)