### PR TITLE
Fix wrong static declaration

### DIFF
--- a/bin/vinyld/http1/cache_http1_vfp.c
+++ b/bin/vinyld/http1/cache_http1_vfp.c
@@ -194,7 +194,7 @@ static enum vfp_status v_matchproto_(vfp_pull_f)
 v1f_chunked_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
     ssize_t *lp)
 {
-	static enum vfp_status vfps;
+	enum vfp_status vfps;
 	struct http_conn *htc;
 	ssize_t l, lr;
 


### PR DESCRIPTION
Introduced in ba59fd2d0dd88022d7390a5d943f458a45fc5e6d

---

Backporting https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/67364d04a29638ed091171e0152ce5be13d3be28