### PR TITLE
Add missing url field to varnishlog-json output

### DIFF
--- a/bin/varnishlog-json/README.md
+++ b/bin/varnishlog-json/README.md
@@ -61,6 +61,7 @@ We'll use `typescript` notation to describe the object shape:
         headers: Map<string, string>,           // keys (header names) are lowercase, this map is built using ReqHeader,
                                                 // BereqHeader, RespUnset, and BerespUnset tags
         method: string,                         // ReqMethod, BereqMethod
+        url: string,                            // ReqURL, BereqURL
         proto: string,                          // ReqProtocol, BereqProtocol
         hdrBytes: number,                       // ReqAcct, BereqAcct
         bodyBytes: number,                      // ^ same


### PR DESCRIPTION
# Summary

The `url` field in the req property was missing from the `varnishlog-json` docs - the program emits it correctly though. 