### PR TITLE
Support TLS backends in pipe mode

### DIFF
--- a/bin/vinyld/cache/cache_backend.c
+++ b/bin/vinyld/cache/cache_backend.c
@@ -536,8 +536,9 @@ vbe_dir_http1pipe(VRT_CTX, VCL_BACKEND d)
 				deadline = cache_param->pipe_task_deadline;
 			if (deadline > 0.)
 				deadline += ctx->req->sp->t_idle;
-			retval = V1P_Process(ctx->req, *PFD_Fd(pfd), &v1a,
-			    deadline);
+			retval = V1P_Process(ctx->req, *PFD_Fd(pfd),
+			    ctx->bo->htc->oper, ctx->bo->htc->oper_priv,
+			    &v1a, deadline);
 		}
 		VSLb_ts_req(ctx->req, "PipeSess", W_TIM_real(ctx->req->wrk));
 		ctx->bo->htc->doclose = retval;

--- a/bin/vinyld/http1/cache_http1.h
+++ b/bin/vinyld/http1/cache_http1.h
@@ -30,6 +30,7 @@
  */
 
 struct VSC_vbe;
+struct vco;
 
 /* cache_http1_fetch.c [V1F] */
 int V1F_SendReq(struct worker *, struct busyobj *, uint64_t *ctr_hdrbytes,
@@ -54,11 +55,9 @@ struct v1p_acct {
 
 int V1P_Enter(void);
 void V1P_Leave(void);
-stream_close_t V1P_Process(const struct req *, int fd, struct v1p_acct *,
-    vtim_real deadline);
+stream_close_t V1P_Process(const struct req *, int fd, const struct vco *,
+    void *oper_priv, struct v1p_acct *, vtim_real deadline);
 void V1P_Charge(struct req *, const struct v1p_acct *, struct VSC_vbe *);
-
-struct vco;
 
 /* cache_http1_line.c */
 void V1L_Chunked(struct v1l *v1l);

--- a/bin/vinyld/http1/cache_http1_pipe.c
+++ b/bin/vinyld/http1/cache_http1_pipe.c
@@ -123,8 +123,8 @@ V1P_Charge(struct req *req, const struct v1p_acct *a, struct VSC_vbe *b)
 }
 
 stream_close_t
-V1P_Process(const struct req *req, int fd, struct v1p_acct *v1a,
-    vtim_real deadline)
+V1P_Process(const struct req *req, int fd, const struct vco *oper,
+    void *oper_priv, struct v1p_acct *v1a, vtim_real deadline)
 {
 	struct pollfd fds[2];
 	struct rdf_vco rdf_c, rdf_b;
@@ -136,17 +136,17 @@ V1P_Process(const struct req *req, int fd, struct v1p_acct *v1a,
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	CHECK_OBJ_NOTNULL(req->sp, SESS_MAGIC);
 	assert(fd > 0);
+	AN(oper);
 
 	/* Client side VCO */
 	rdf_c.fd = req->sp->fd;
 	rdf_c.oper = req->htc->oper;
 	rdf_c.oper_priv = req->htc->oper_priv;
 
-	/* Backend side - use VCO_default for now
-	 * TODO: When backend TLS is implemented, pass oper from pfd */
+	/* Backend side VCO */
 	rdf_b.fd = fd;
-	rdf_b.oper = VCO_default;
-	rdf_b.oper_priv = NULL;
+	rdf_b.oper = oper;
+	rdf_b.oper_priv = oper_priv;
 
 	if (req->htc->pipeline_b != NULL) {
 		j = rdf_b.oper->write(rdf_b.oper_priv, rdf_b.fd,

--- a/bin/vinyltest/tests/T00011.vtc
+++ b/bin/vinyltest/tests/T00011.vtc
@@ -1,0 +1,43 @@
+varnishtest "Pipe WebSocket over a TLS backend"
+
+server s1 {
+	tls_handshake
+	rxreq
+	expect req.http.Upgrade == websocket
+	txresp -status 101 -nolen \
+	    -hdr "Connection: Upgrade" \
+	    -hdr "Upgrade: websocket"
+	send "pong"
+	recv 4
+} -start
+
+varnish v1 -vcl {
+	backend default {
+		.host = "${s1_addr}";
+		.port = "${s1_port}";
+		.ssl = 1;
+		.ssl_verify_peer = 0;
+	}
+
+	sub vcl_recv {
+		if (req.http.Upgrade ~ "(?i)websocket") {
+			return (pipe);
+		}
+	}
+
+	sub vcl_pipe {
+		set bereq.http.Upgrade = req.http.Upgrade;
+		set bereq.http.Connection = req.http.Connection;
+	}
+} -start
+
+client c1 {
+	txreq \
+	    -hdr "Connection: Upgrade" \
+	    -hdr "Upgrade: websocket"
+	rxresp
+	expect resp.status == 101
+	expect resp.http.Upgrade == websocket
+	recv 4
+	send "ping"
+} -run


### PR DESCRIPTION
Pipe mode always used `VCO_default` for backend reads and writes. That bypasses the TLS connection operator when a backend has `.ssl = 1`, so WebSocket upgrades fail after the request is sent.

Pass the backend connection operator and private data into `V1P_Process()` and use them for piped traffic.

Adds a regression test for a WebSocket upgrade and bidirectional traffic through a TLS backend.

Tested with `T00000` through `T00008` and the new `T00011`.

Fixes #64.