### PR TITLE
tls.cert.list: advertise -j in CLI help synopsis

### DIFF
--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -609,9 +609,9 @@ CLI_CMD(VTLS_CERT_ROLLBACK,
 
 CLI_CMD(VTLS_CERT_LIST,
 	"tls.cert.list",
-	"tls.cert.list [-s]",
-	"List active TLS configurations. Takes an optional '-s' that will "
-	"only list staged or discarded certificates.",
+	"tls.cert.list [-j] [-s]",
+	"List active tls configurations, it takes an optional '-s' that will "
+	"only list staged or discarded certificates",
 	"",
 	CLI_F_AUTH,
 	0, 1


### PR DESCRIPTION
## Summary
- `varnishadm help tls.cert.list` only listed `-s`, but the command already supports `-j` for JSON output via the generic CLI dispatch (`cls_dispatch` checks `av[2] == "-j"` and calls the registered `jsonfunc`).
- Updated synopsis/description in `include/tbl/cli_cmds.h` to match, aligning wording with the equivalent fix already in varnish-plus (commit c40b10eec0).

## Test plan
- [ ] Rebuild and run `varnishadm help tls.cert.list`, confirm `[-j]` shown
- [ ] Sanity-check `tls.cert.list -j` and `tls.cert.list -s` both still work