### PR TITLE
mgt: fix tls.cert.list -j returning empty 200 when child not running (#68)

### DIFF
--- a/bin/vinyld/mgt/mgt_tls_conf.c
+++ b/bin/vinyld/mgt/mgt_tls_conf.c
@@ -1036,6 +1036,8 @@ mgt_tls_cert_list(struct cli *cli, const char *const *av, void *priv,
 		VCLI_Out(cli, "%s", p);
 		VCLI_SetResult(cli, status);
 		free(p);
+	} else if (json) {
+		VCLI_Out(cli, "[]");
 	}
 }
 

--- a/bin/vinyltest/tests/varnish_r00068.vtc
+++ b/bin/vinyltest/tests/varnish_r00068.vtc
@@ -1,0 +1,5 @@
+vtest "tls.cert.list -j returns empty body when child is stopped"
+
+varnish v1 -arg "-a :0,https"
+
+varnish v1 -clijson "tls.cert.list -j"

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -41,6 +41,10 @@ Varnish-Cache NEXT (unreleased)
 .. PLEASE keep this roughly in commit order as shown by git-log / tig
    (new to old)
 
+* ``tls.cert.list -j`` no longer returns an empty body with a ``200``
+  status when the child process is not running; it now returns an
+  empty JSON array (``[]``).
+
 .. _VSV00019: https://vinyl-cache.org/security/VSV00019.html
 
 * A deficiency in HTTP/2 request parsing has been fixed by properly comparing


### PR DESCRIPTION
## Summary
- Fixes #68: `tls.cert.list -j` returned CLI status 200 with an empty body when the child process was not running, instead of a valid JSON response. Root cause and discussion in #68, discovered via review comment on varnish/varnish-go#35.
- `mgt_tls_cert_list()` (`bin/vinyld/mgt/mgt_tls_conf.c`) only produced output `if (MCH_Running())`; the CLI dispatcher's default `CLIS_OK` result was left untouched with no body otherwise. Now emits `"[]"` when JSON output is requested and the child isn't running.
- Adds `bin/vinyltest/tests/varnish_r00068.vtc`, a reproducer/regression test.
- Adds a `doc/changes.rst` entry.

## Test plan
- [x] Rebuilt `varnishd` with the fix, ran `./varnishtest -v tests/varnish_r00068.vtc` against it: passes.
- [x] Confirmed it fails the same way as before against an unpatched build (empty body, status 200).

Fixes #68