### PR TITLE
poll: don't wait indefinitely if we miss an event

### DIFF
--- a/bin/vinyld/waiter/cache_waiter_poll.c
+++ b/bin/vinyld/waiter/cache_waiter_poll.c
@@ -171,8 +171,11 @@ vwp_main(void *priv)
 		then = Wait_HeapDue(w, &wp);
 		if (wp == NULL)
 			t = -1;
-		else
+		else {
 			t = (int)floor(1e3 * (then - VTIM_real()));
+			if (t < 0)
+				t = 0;
+		}
 		assert(vwp->hpoll > 0);
 		AN(vwp->pollfd);
 		v = poll(vwp->pollfd, vwp->hpoll, t);


### PR DESCRIPTION
Backport of vinyl-cache [#4561](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4561).

If the computed poll() timeout `t` in `vwp_main()` is negative (i.e. the deadline already passed), `poll()` treats a negative timeout as "wait forever" rather than returning immediately. Clamp `t` to 0 in that case.

Part of the backport tracking list in #70.