### PR TITLE
proxy2: protect OOB reading/writing

### DIFF
--- a/bin/vinyld/proxy/cache_proxy_proto.c
+++ b/bin/vinyld/proxy/cache_proxy_proto.c
@@ -452,7 +452,12 @@ vpx_proto2(const struct worker *wrk, const struct req *req)
 			}
 			vpi->e = vpi2->e;
 		} else if (vpi->t == PP2_TYPE_CRC32C) {
-			uint32_t n_crc32c = vbe32dec(vpi->p);
+			uint32_t n_crc32c;
+			if (vpi->l != 4) {
+				vpi->e = "Length Error";
+				break;
+			}
+			n_crc32c = vbe32dec(vpi->p);
 			vbe32enc(vpi->p, 0);
 			if (crc32c(p, hdr_len) != n_crc32c) {
 				VSL(SLT_ProxyGarbage, req->sp->vxid,


### PR DESCRIPTION
Backport of vinyl-cache [#4560](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4560).

`vpx_proto2()`'s `PP2_TYPE_CRC32C` branch decoded/re-encoded 4 bytes from `vpi->p` without checking the TLV's actual length, allowing an out-of-bounds read/write for a malformed PROXY2 CRC32C TLV. Guard with `vpi->l != 4`, matching the existing error idiom already used by the `PP2_TYPE_SSL` branch in the same function.

Part of the backport tracking list in #70.