### PR TITLE
math.strfromd() refuses formatting junk

### DIFF
--- a/bin/vinyltest/tests/r04546.vtc
+++ b/bin/vinyltest/tests/r04546.vtc
@@ -1,0 +1,22 @@
+vtest "math.strfromd() refuses trailing format garbage"
+
+vinyl v1 -vcl {
+	import math;
+
+	backend default none;
+
+	sub vcl_recv {
+		math.strfromd("%f%n", 1.5);
+		return (synth(200));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+logexpect l1 -v v1 -d 1 -g raw -q "VCL_Error" {
+	expect * * VCL_Error {Invalid format}
+} -run

--- a/bin/vinyltest/tests/r04546.vtc
+++ b/bin/vinyltest/tests/r04546.vtc
@@ -1,6 +1,6 @@
 vtest "math.strfromd() refuses trailing format garbage"
 
-vinyl v1 -vcl {
+varnish v1 -vcl {
 	import math;
 
 	backend default none;

--- a/vmod/vmod_math_util.c
+++ b/vmod/vmod_math_util.c
@@ -82,6 +82,10 @@ valid_fmt(VCL_STRING fmt)
 		while (*fmt >= '0' && *fmt <= '9')
 			fmt++;
 	}
+
+	if (fmt[0] == '\0' || fmt[1] != '\0')
+		return (0);
+
 	switch (*fmt) {
 	case 'a':
 	case 'A':


### PR DESCRIPTION
Backport of vinyl-cache [#4547](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4547).

`valid_fmt()` accepted a format spec followed by trailing garbage (e.g. `"%f%n"`), since it only checked the conversion character itself and never verified nothing was left after it. Reject the format string if anything remains after the conversion character.

Part of the backport tracking list in #70.