### PR TITLE
Drop ban_mtx during STV_BanExport()

### DIFF
--- a/bin/vinyld/cache/cache_ban.c
+++ b/bin/vinyld/cache/cache_ban.c
@@ -347,8 +347,10 @@ ban_export(void)
 		AZ(VSB_bcat(vsb, b->spec, ban_len(b->spec)));
 	AZ(VSB_finish(vsb));
 	assert(VSB_len(vsb) == ln);
+	Lck_Unlock(&ban_mtx);
 	STV_BanExport((const uint8_t *)VSB_data(vsb), VSB_len(vsb));
 	VSB_destroy(&vsb);
+	Lck_Lock(&ban_mtx);
 	VSC_C_main->bans_persisted_bytes =
 	    bans_persisted_bytes = ln;
 	VSC_C_main->bans_persisted_fragmentation =
@@ -364,7 +366,6 @@ ban_export(void)
 void
 ban_info_new(const uint8_t *ban, unsigned len)
 {
-	/* XXX martin pls review if ban_mtx needs to be held */
 	Lck_AssertHeld(&ban_mtx);
 	if (STV_BanInfoNew(ban, len))
 		ban_export();
@@ -373,7 +374,6 @@ ban_info_new(const uint8_t *ban, unsigned len)
 void
 ban_info_drop(const uint8_t *ban, unsigned len)
 {
-	/* XXX martin pls review if ban_mtx needs to be held */
 	Lck_AssertHeld(&ban_mtx);
 	if (STV_BanInfoDrop(ban, len))
 		ban_export();

--- a/bin/vinyld/cache/cache_ban_build.c
+++ b/bin/vinyld/cache/cache_ban_build.c
@@ -396,9 +396,6 @@ BAN_Commit(struct ban_proto *bp)
 	if (b->flags & BANS_FLAG_REQ)
 		VSC_C_main->bans_req++;
 
-	if (bi != NULL)
-		ban_info_new(b->spec, ln);	/* Notify stevedores */
-
 	if (cache_param->ban_dups) {
 		/* Hunt down duplicates, and mark them as completed */
 		for (bi = VTAILQ_NEXT(b, list); bi != NULL;
@@ -410,8 +407,12 @@ BAN_Commit(struct ban_proto *bp)
 			}
 		}
 	}
+
 	if (!(b->flags & BANS_FLAG_REQ))
 		ban_kick_lurker();
+
+	if (bi != NULL)
+		ban_info_new(b->spec, ln);	/* Notify stevedores */
 	Lck_Unlock(&ban_mtx);
 
 	BAN_Abandon(bp);


### PR DESCRIPTION
Backport of vinyl-cache [#3853](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/3853).

`STV_BanExport()` can do I/O and doesn't need `ban_mtx` held; release it around that call and re-acquire after. In `BAN_Commit()`, move the `ban_info_new()` stevedore notification to after the duplicate-scan and lurker-kick so it doesn't run in the middle of that sequence.

**Two things worth reviewer awareness, both inherited from upstream's merged commit as-is (confirmed against their `.diff`, not introduced by this backport):**
- After the reorder in `BAN_Commit()`, `bi` is reassigned by the duplicate-scan loop before the `if (bi != NULL) ban_info_new(...)` check, so that call is effectively unreachable whenever `cache_param->ban_dups` is set. This matches upstream's shipped code exactly.
- `ban_export()`'s `ln` is computed once under the lock before it's dropped around `STV_BanExport()`; a second thread entering `ban_export()` during that window could have its own update clobbered by this one's stale `ln` on re-lock. This is the accepted tradeoff of the upstream fix (dropping the lock around I/O is the point of the change), not something this backport is altering.

Part of the backport tracking list in #70.