### PR TITLE
Consistently rewrite both IPv4-compatible-IPv6 and IPv4-mapped-IPv6 addresses

### DIFF
--- a/bin/vinyltest/tests/i00002.vtc
+++ b/bin/vinyltest/tests/i00002.vtc
@@ -1,0 +1,42 @@
+vtest "Normalization of IPv4 compatible and mapped IPv6 addresses"
+
+feature ipv4
+feature ipv6
+
+server s1 {
+	rxreq
+	txresp -body "012345\n"
+} -start
+
+varnish v1 -proto PROXY -vcl+backend {
+
+	acl a0 {
+		"192.168/16";
+	}
+
+	acl a1 {
+		"168.192/16";
+	}
+
+	sub vcl_deliver {
+		set resp.http.ca = client.ip;
+		set resp.http.sa = server.ip;
+		set resp.http.la = local.ip;
+		set resp.http.ra = remote.ip;
+		set resp.http.cm = (client.ip ~ a0) + " - " + (client.ip ~ a1);
+		set resp.http.sm = (server.ip ~ a0) + " - " + (server.ip ~ a1);
+	}
+
+} -start
+
+client c1 -proxy1 "[::c0a8:c0a8]:1234 [::ffff:a8c0:a8c0]:5678" {
+
+	txreq -url "/1"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.ca == "192.168.192.168"
+	expect resp.http.sa == "168.192.168.192"
+	expect resp.http.cm == "true - false"
+	expect resp.http.sm == "false - true"
+
+} -run

--- a/lib/libvinyl/vsa.c
+++ b/lib/libvinyl/vsa.c
@@ -157,13 +157,16 @@
  * I have decided to try to contain this crap in this single
  * source-file, with only minimum leakage into the rest of Varnish,
  * which will only know of pointers to "struct suckaddr", the naming
- * of which is my of the historical narrative above.
+ * of which is my considered opinion of the historical narrative above.
  *
  * And you don't need to take my word for this, you can see it all
  * in various #include files on your own system.   If you are on
  * a Solaris derivative, don't miss the beautiful horror hidden in the
  * variant definition of IPv6 addresses between kernel and userland.
  *
+ * Update (2026): Gosh, who could ever have foreseen that IPv4
+ * mapped into IPv6 would become a mess ?   Now we normalize
+ * all such VSAs to IPv4 at the VSA level.
  */
 
 struct suckaddr {
@@ -187,6 +190,52 @@ const struct suckaddr *bogo_ip = &bogo_ip_vsa;
 /* same in IPv6 */
 static struct suckaddr bogo_ip6_vsa;
 const struct suckaddr *bogo_ip6 = &bogo_ip6_vsa;
+
+static const uint8_t map4_0_80[10] = {0,0,0,0,0,0,0,0,0,0};
+static const uint8_t map4_0_104[13] = {0,0,0,0,0,0,0,0,0,0,0,0,0};
+static const uint8_t map4_0_96[12] = {0,0,0,0,0,0,0,0,0,0,0x00,0x00};
+static const uint8_t map4_ffff_96[12] = {0,0,0,0,0,0,0,0,0,0,0xff,0xff};
+
+/*
+ * Rewrite IPv4-in-IPv6 suckaddr's in place
+ */
+
+static void
+vsa_normalize(struct suckaddr *sua)
+{
+	CHECK_OBJ_NOTNULL(sua, SUCKADDR_MAGIC);
+	if (sua->u.sa.sa_family != PF_INET6)
+		return;
+	uint8_t *p6 = (void*)&sua->u.sa6.sin6_addr;
+
+	if (memcmp(p6, map4_0_80, sizeof map4_0_80)) {
+		// A "normal" IPv6 address.
+		return;
+	}
+
+	if (!memcmp(p6, map4_0_104, sizeof map4_0_104)) {
+		// IPv6 loopback
+		// IPv6 "any"
+		// IPv4-compat-IPv6, but IPv4 is in 0/8 IPv4
+		return;
+	}
+
+	if (!memcmp(p6, map4_0_96, sizeof map4_0_96)) {
+		// RFC3513 2.5.5 - convert
+	} else if (!memcmp(p6, map4_ffff_96, sizeof map4_ffff_96)) {
+		// RFC4291 2.5.5.2 - convert
+	} else {
+		return;
+	}
+
+	uint8_t *p4 = (void*)&sua->u.sa4.sin_addr;
+	sua->u.sa.sa_family = PF_INET;
+	memcpy(p4, p6+12, 4);
+
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+	sua->u.sa.sa_len = sizeof(sua->u.sa4);
+#endif
+}
 
 void
 VSA_Init(void)
@@ -228,8 +277,8 @@ VSA_GetPtr(const struct suckaddr *sua, const unsigned char ** dst)
  * Return the size of a struct sockaddr in a struck suckaddr
  * or 0 if unknown family
  */
-static inline
-socklen_t sua_len(const struct sockaddr *sa)
+static inline socklen_t
+sua_len(const struct sockaddr *sa)
 {
 
 	switch (sa->sa_family) {
@@ -332,9 +381,11 @@ VSA_Build(void *d, const void *s, unsigned sal)
 	switch (l) {
 	case sizeof sua->u.sa4:
 		memcpy(&sua->u.sa4, s, l);
+		assert(sua->u.sa.sa_family == PF_INET);
 		break;
 	case sizeof sua->u.sa6:
 		memcpy(&sua->u.sa6, s, l);
+		assert(sua->u.sa.sa_family == PF_INET6);
 		break;
 	default:
 		WRONG("VSA protocol vs. size");
@@ -342,6 +393,7 @@ VSA_Build(void *d, const void *s, unsigned sal)
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
 	sua->u.sa.sa_len = (unsigned char)l;
 #endif
+	vsa_normalize(sua);
 	return (sua);
 }
 
@@ -451,9 +503,11 @@ VSA_get ## which ## name(int fd, void *d, size_t l)	\
 	INIT_OBJ(sua, SUCKADDR_MAGIC);			\
 	sl = sizeof(sua->u);				\
 	r = get ## which ## name(fd, &sua->u.sa, &sl);	\
-							\
-	return (r == 0 ? sua : NULL);			\
-}							\
+	if (r != 0)					\
+		return (NULL);				\
+	vsa_normalize(sua);				\
+	return (sua);					\
+}
 
 VSA_getname(sock)
 VSA_getname(peer)

--- a/lib/libvinyl/vtcp.c
+++ b/lib/libvinyl/vtcp.c
@@ -83,12 +83,6 @@ vtcp_sa_to_ascii(const void *sa, socklen_t l, char *abuf, unsigned alen,
 			(void)snprintf(pbuf, plen, "Failed");
 		return;
 	}
-	/* XXX dirty hack for v4-to-v6 mapped addresses */
-	if (abuf != NULL && strncmp(abuf, "::ffff:", 7) == 0) {
-		for (i = 0; abuf[i + 7]; ++i)
-			abuf[i] = abuf[i + 7];
-		abuf[i] = '\0';
-	}
 }
 
 /*--------------------------------------------------------------------*/


### PR DESCRIPTION
Backport of vinyl-cache [#4474](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4474).

Adds `vsa_normalize()` in `lib/libvinyl/vsa.c`, which rewrites IPv4-mapped (`::ffff:a.b.c.d`) and IPv4-compatible (`::a.b.c.d`) IPv6 addresses to plain IPv4 `struct suckaddr`s in place, called from `VSA_Build()` and from `VSA_getsockname()`/`VSA_getpeername()`. This replaces the previous string-based `"::ffff:"` prefix-stripping hack in `vtcp_sa_to_ascii()`, which only fixed the textual representation and not comparisons/ACLs done on the raw address (e.g. `client.ip ~ acl` against a v4 ACL entry for a v4-mapped client).

Part of the backport tracking list in #70.