### PR TITLE
lru: Do not add failed objects

### DIFF
--- a/bin/vinyld/storage/storage_lru.c
+++ b/bin/vinyld/storage/storage_lru.c
@@ -87,7 +87,7 @@ LRU_Add(struct objcore *oc, vtim_real now)
 
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
-	if (oc->flags & OC_F_PRIVATE)
+	if (oc->flags & (OC_F_PRIVATE|OC_F_FAILED))
 		return;
 
 	AZ(oc->boc);
@@ -109,7 +109,7 @@ LRU_Remove(struct objcore *oc)
 
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
-	if (oc->flags & OC_F_PRIVATE)
+	if (oc->flags & (OC_F_PRIVATE|OC_F_FAILED))
 		return;
 
 	AZ(oc->boc);
@@ -130,7 +130,7 @@ LRU_Touch(struct worker *wrk, struct objcore *oc, vtim_real now)
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
-	if (oc->flags & OC_F_PRIVATE || isnan(oc->last_lru))
+	if (oc->flags & (OC_F_PRIVATE|OC_F_FAILED) || isnan(oc->last_lru))
 		return;
 
 	/*
@@ -182,6 +182,7 @@ LRU_NukeOne(struct worker *wrk, struct lru *lru)
 	Lck_Lock(&lru->mtx);
 	VTAILQ_FOREACH_SAFE(oc, &lru->lru_head, lru_list, oc2) {
 		CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+		AZ(oc->flags & (OC_F_PRIVATE|OC_F_FAILED));
 		AZ(isnan(oc->last_lru));
 
 		VSLb(wrk->vsl, SLT_ExpKill, "LRU_Cand p=%p f=0x%x r=%d",


### PR DESCRIPTION
Backport of vinyl-cache [#4428](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4428).

`LRU_Add`/`LRU_Remove`/`LRU_Touch` only excluded `OC_F_PRIVATE` objects from the LRU list, not `OC_F_FAILED` ones. Skip both, and assert the invariant holds in `LRU_NukeOne()`.

Part of the backport tracking list in #70.