### PR TITLE
expire: Force a cache MISS when req.max_age = 0s

### DIFF
--- a/bin/vinyld/cache/cache_expire.c
+++ b/bin/vinyld/cache/cache_expire.c
@@ -73,7 +73,7 @@ EXP_Ttl(const struct req *req, const struct objcore *oc)
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
 	r = oc->ttl;
-	if (req != NULL && req->d_ttl > 0. && req->d_ttl < r)
+	if (req != NULL && req->d_ttl >= 0. && req->d_ttl < r)
 		r = req->d_ttl;
 	return (oc->t_origin + r);
 }

--- a/bin/vinyltest/tests/b00100.vtc
+++ b/bin/vinyltest/tests/b00100.vtc
@@ -1,0 +1,100 @@
+vtest "req.max_age = 0s forces cache MISS with request coalescing"
+
+barrier b1 cond 3 -cyclic
+barrier b2 sock 2 -cyclic
+
+server s1 {
+	rxreq
+	txresp -nolen -hdr "Content-Length: 3" -hdr "version: 1"
+	barrier b1 sync
+	send "foo"
+
+	rxreq
+	txresp -nolen -hdr "Content-Length: 3" -hdr "version: 2"
+	barrier b1 sync
+	send "bar"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_recv {
+		if (req.http.max-age) {
+			set req.max_age = std.duration(req.http.max-age, 0s);
+		}
+
+		# Make sure both client tasks are started before the fetch is
+		# initiated to guarantee that one ends up on the waitinglist.
+		if (req.http.sync) {
+			vtc.barrier_sync("${b2_sock}");
+		}
+	}
+} -start
+
+# c1 and c2 send a request and sync on the barrier only after having received
+# headers. This ensures that the two requests are coalesced.
+
+client c1 {
+	txreq -hdr "sync: yes" -hdr "max-age: 0s"
+	rxresphdrs
+	expect resp.status == 200
+	expect resp.http.version == "1"
+	barrier b1 sync
+	rxrespbody
+	expect resp.body == "foo"
+} -start
+
+client c2 {
+	txreq -hdr "sync: yes" -hdr "max-age: 0s"
+	rxresphdrs
+	expect resp.status == 200
+	expect resp.http.version == "1"
+	barrier b1 sync
+	rxrespbody
+	expect resp.body == "foo"
+} -start
+
+client c1 -wait
+client c2 -wait
+
+# c3 checks that a positive or unset req.max_age gets the cached object.
+
+client c3 {
+	txreq -hdr "max-age: 10s"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.version == "1"
+	expect resp.body == "foo"
+
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.version == "1"
+	expect resp.body == "foo"
+} -run
+
+# c4 and c5 force a cache MISS, where the two requests are again coalesced.
+
+client c4 {
+	txreq -hdr "sync: yes" -hdr "max-age: 0s"
+	rxresphdrs
+	expect resp.status == 200
+	expect resp.http.version == "2"
+	barrier b1 sync
+	rxrespbody
+	expect resp.body == "bar"
+} -start
+
+client c5 {
+	txreq -hdr "sync: yes" -hdr "max-age: 0s"
+	rxresphdrs
+	expect resp.status == 200
+	expect resp.http.version == "2"
+	barrier b1 sync
+	rxrespbody
+	expect resp.body == "bar"
+} -start
+
+client c4 -wait
+client c5 -wait


### PR DESCRIPTION
Backport of vinyl-cache [#4041](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4041).

`req.max_age = 0` was treated the same as "unset" (`EXP_Ttl()` only honored strictly positive overrides), so it silently did nothing instead of forcing a cache MISS. Accept 0 as a valid override.

Part of the backport tracking list in #70.