### PR TITLE
std.strftime() guards against NULL input

### DIFF
--- a/bin/vinyltest/tests/r04550.vtc
+++ b/bin/vinyltest/tests/r04550.vtc
@@ -1,0 +1,21 @@
+vtest "std.strftime() NULL check"
+
+varnish v1 -vcl {
+	import std;
+
+	backend default none;
+
+	sub vcl_recv {
+		std.strftime(now, req.http.nonexist);
+		return(synth(200));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+logexpect l1 -v v1 -d 1 -g raw -q "VCL_Error" {
+		expect * * VCL_Error {std.strftime: fmt STRING can't be NULL}
+} -run

--- a/vmod/vmod_std_conversions.c
+++ b/vmod/vmod_std_conversions.c
@@ -338,6 +338,11 @@ vmod_strftime(VRT_CTX, VCL_TIME t, VCL_STRING fmt)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
+	if (fmt == NULL) {
+		VRT_fail(ctx, "std.strftime: fmt STRING can't be NULL");
+		return ("");
+	}
+
 	tt = (time_t)(intmax_t)t;
 	if (gmtime_r(&tt, &tm) == NULL)
 		return ("");


### PR DESCRIPTION
Backport of vinyl-cache [#4551](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4551).

`vmod_strftime()` proceeded with a NULL `fmt` argument instead of rejecting it. Reject with a clear `VRT_fail()` error instead.

Part of the backport tracking list in #70.