### PR TITLE
blob.sub() errors out on negative BYTES arguments

### DIFF
--- a/bin/vinyltest/tests/r04548.vtc
+++ b/bin/vinyltest/tests/r04548.vtc
@@ -1,0 +1,23 @@
+vtest "blob.encode() panics on negative BYTES"
+
+varnish v1 -vcl {
+	import blob;
+	import std;
+
+	backend default none;
+
+	sub vcl_recv {
+		blob.sub(blob.decode(HEX, encoded="666f6f"), 1B - 2B);
+		return (synth(203));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+logexpect l1 -v v1 -d 1 -g raw -q "VCL_Error" {
+	expect * * VCL_Error {size or offset negative in blob.sub}
+} -run

--- a/vmod/vmod_blob.c
+++ b/vmod/vmod_blob.c
@@ -533,8 +533,6 @@ vmod_sub(VRT_CTX, VCL_BLOB b, VCL_BYTES n, VCL_BYTES off)
 {
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	assert(n >= 0);
-	assert(off >= 0);
 
 	CHECK_OBJ_ORNULL(b, VRT_BLOB_MAGIC);
 	if (b == NULL || b->len == 0 || b->blob == NULL) {


### PR DESCRIPTION
Backport of vinyl-cache [#4549](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4549).

`vmod_sub()` asserted (panicked) on a negative offset/size instead of reaching the graceful error path (`ERR(ctx, "size or offset negative in blob.sub()")`) already further down in the same function. Drop the premature asserts.

Part of the backport tracking list in #70.