### PR TITLE
http: Ignore range header for non-GET requests

### DIFF
--- a/bin/vinyld/builtin.vcl
+++ b/bin/vinyld/builtin.vcl
@@ -64,6 +64,7 @@ sub vcl_builtin_recv {
 	call vcl_req_method;
 	call vcl_req_authorization;
 	call vcl_req_cookie;
+	call vcl_req_range;
 }
 
 sub vcl_req_host {
@@ -118,6 +119,13 @@ sub vcl_req_cookie {
 	if (req.http.Cookie) {
 		# Risky to cache by default.
 		return (pass);
+	}
+}
+
+sub vcl_req_range {
+	# Ref: https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2
+	if (req.method != "GET") {
+		unset req.http.Range;
 	}
 }
 

--- a/bin/vinyld/cache/cache_http.c
+++ b/bin/vinyld/cache/cache_http.c
@@ -968,6 +968,10 @@ http_GetRange(const struct http *hp, ssize_t *lo, ssize_t *hi, ssize_t len)
 	if (!http_GetHdr(hp, H_Range, &b))
 		return (NULL);
 
+	// rfc9110,l,6481,6484
+	if (!http_method_eq(hp->wkm, WKM_GET))
+		return (NULL);
+
 	t = strchr(b, '=');
 	if (t == NULL)
 		return ("Missing '='");

--- a/bin/vinyltest/tests/c00139.vtc
+++ b/bin/vinyltest/tests/c00139.vtc
@@ -1,0 +1,30 @@
+vtest "HEAD + range header"
+
+server s0 {
+        rxreq
+        txresp -bodylen 1024
+} -dispatch
+
+varnish v1 -vcl+backend { } -start
+
+client c1 {
+        txreq -req HEAD -hdr "Range: bytes=11-40"
+        rxresp -no_obj
+        expect resp.status == 200
+        expect resp.http.content-length == 1024
+        expect resp.http.content-range == <undef>
+} -run
+
+varnish v1 -vcl+backend {
+	sub vcl_req_range {
+		return;
+	}
+}
+
+client c2 {
+        txreq -url /2 -req HEAD -hdr "Range: bytes=11-40"
+        rxresp -no_obj
+        expect resp.status == 200
+        expect resp.http.content-length == 1024
+        expect resp.http.content-range == <undef>
+} -run


### PR DESCRIPTION
Backport of vinyl-cache [#4533](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4533).

Per [RFC 9110 §14.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2), `Range` only applies to `GET`. Unset it early in `vcl_builtin_recv` (new `vcl_req_range` sub), and guard `http_GetRange()` itself against non-GET as a second line of defense (belt and suspenders — the C-level guard still applies even if `vcl_req_range` is overridden to a no-op).

Part of the backport tracking list in #70.