### PR TITLE
varnishtest: Fork and clean up FD table before running tests

### DIFF
--- a/doc/sphinx/reference/varnishtest.rst
+++ b/doc/sphinx/reference/varnishtest.rst
@@ -67,6 +67,11 @@ file             File to use as a script
 If `TMPDIR` is set in the environment, varnishtest creates temporary
 `vtc.*` directories for each test in `$TMPDIR`, otherwise in `/tmp`.
 
+At several points during a test, the process will be forked and excess file
+descriptors are closed. This can consume significant amounts of time and CPU on
+systems without the `closefrom` system call, or read access to `/proc/<PID>/fd`,
+and can be mitigated by lowering the file descriptor limit.
+
 SCRIPTS
 =======
 


### PR DESCRIPTION
Backport of vinyl-cache [#3891](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/3891).

`VSUB_closefrom()` scanned `/proc/<pid>/fd` twice: once to find the highest open fd, then again to close everything down to it. Close each fd as it's found instead, and only fall back to `sysconf(_SC_OPEN_MAX)` when `/proc` isn't readable at all.

Part of the backport tracking list in #70.