### PR TITLE
std.fileread(): don't panic on 0-length files

### DIFF
--- a/bin/vinyltest/tests/r04557.vtc
+++ b/bin/vinyltest/tests/r04557.vtc
@@ -1,0 +1,22 @@
+vtest "std.fileread() doesn't assert on empty file"
+
+shell {
+	touch ${tmpdir}/empty
+}
+
+varnish v1 -vcl {
+	import std;
+
+	backend default none;
+
+	sub vcl_recv {
+		std.fileread("${tmpdir}/empty");
+		return(synth(200));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run

--- a/vmod/vmod_std_fileread.c
+++ b/vmod/vmod_std_fileread.c
@@ -95,7 +95,7 @@ find_frfile(struct vmod_priv *priv, VCL_STRING file_name)
 {
 	struct frfile *frf = NULL;
 	char *s;
-	ssize_t sz;
+	ssize_t sz = -1;
 
 	AN(priv);
 
@@ -126,7 +126,7 @@ find_frfile(struct vmod_priv *priv, VCL_STRING file_name)
 
 	s = VFIL_readfile(NULL, file_name, &sz);
 	if (s != NULL) {
-		assert(sz > 0);
+		assert(sz >= 0);
 		ALLOC_OBJ(frf, CACHED_FILE_MAGIC);
 		AN(frf);
 		REPLACE(frf->file_name, file_name);


### PR DESCRIPTION
Backport of vinyl-cache [#4558](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4558).

`find_frfile()` asserted the read size was strictly positive, panicking on an empty file instead of caching it normally like any other file.

Part of the backport tracking list in #70.