### PR TITLE
vtim.c: use strlen instead of memcmp

### DIFF
--- a/lib/libvinyl/vtim.c
+++ b/lib/libvinyl/vtim.c
@@ -206,7 +206,7 @@ VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE])
 	do {							\
 		int i;						\
 		for (i = 0; i < 7; i++) {			\
-			if (!memcmp(p, weekday_name[i], 3)) {	\
+			if (!strncmp(p, weekday_name[i], 3)) {	\
 				weekday = i;			\
 				break;				\
 			}					\
@@ -221,7 +221,7 @@ VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE])
 	do {							\
 		int i;						\
 		for (i = 0; i < 12; i++) {			\
-			if (!memcmp(p, month_name[i], 3)) {	\
+			if (!strncmp(p, month_name[i], 3)) {	\
 				month = i + 1;			\
 				break;				\
 			}					\
@@ -314,7 +314,7 @@ VTIM_parse(const char *p)
 			DIGIT(100, year);
 			DIGIT(10, year);
 			DIGIT(1, year);
-		} else if (!memcmp(p, more_weekday[weekday],
+		} else if (!strncmp(p, more_weekday[weekday],
 		    strlen(more_weekday[weekday]))) {
 			/* RFC850 -- "Sunday, 06-Nov-94 08:49:37 GMT" */
 			p += strlen(more_weekday[weekday]);


### PR DESCRIPTION
Backport of vinyl-cache [#4554](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4554).

`WEEKDAY()`/`MONTH()` and the RFC850 weekday check in `VTIM_parse()` used `memcmp()` to compare a fixed-length prefix against a table entry; use `strncmp()` instead.

Part of the backport tracking list in #70.