### PR TITLE
vsm: Say which _.index line is malformed

### DIFF
--- a/bin/vinyltest/tests/c00144.vtc
+++ b/bin/vinyltest/tests/c00144.vtc
@@ -1,0 +1,88 @@
+vtest "VSM reader reports which _.index line is malformed"
+
+# _.index is written by vinyld, so a line with the wrong field count is a bug
+# in whatever produced it. The reader refuses the index and stops, and the
+# failure names the line number, the field count against the range the format
+# allows, and the line itself, so the producer can be found.
+
+varnish v1 -vcl {
+	backend default none;
+} -start
+
+delay 0.5
+
+shell {
+	set -e
+
+	# Corrupt copies rather than v1's own workdir, which vinyltest reads
+	# itself. The two message cases only ever reach the management set, so
+	# they copy that alone: the child set is 2.3M of the 2.5M workdir, and
+	# carrying it into a case that never reads it would put that I/O on a
+	# parallel run for nothing.
+	for c in plus minus ; do
+		mkdir -p "${tmpdir}/$c"
+		cp -a "${tmpdir}/v1/_.vsm_mgt" "${tmpdir}/$c/"
+	done
+
+	# The third case does need the child set, so that a reader which
+	# published a partial view would have counters available to publish.
+	cp -a "${tmpdir}/v1" "${tmpdir}/mid"
+
+	# A '+' line with too many fields models a segment name containing
+	# whitespace, which splits into an extra field.
+	printf '+ _.Dictionary.bad na me.deadbeef 0 16 Dictionary x\n' \
+	    | cat - "${tmpdir}/plus/_.vsm_mgt/_.index" \
+	    > "${tmpdir}/plus/_.vsm_mgt/_.index.new"
+	mv "${tmpdir}/plus/_.vsm_mgt/_.index.new" \
+	    "${tmpdir}/plus/_.vsm_mgt/_.index"
+
+	printf -- '- foo bar\n' \
+	    | cat - "${tmpdir}/minus/_.vsm_mgt/_.index" \
+	    > "${tmpdir}/minus/_.vsm_mgt/_.index.new"
+	mv "${tmpdir}/minus/_.vsm_mgt/_.index.new" \
+	    "${tmpdir}/minus/_.vsm_mgt/_.index"
+
+	# The same damage further in, where the reader has already parsed
+	# usable segments before it reaches the bad line.
+	head -2 "${tmpdir}/mid/_.vsm_mgt/_.index" \
+	    > "${tmpdir}/mid/_.vsm_mgt/_.index.new"
+	printf '+ _.Dictionary.bad na me.deadbeef 0 16 Dictionary x\n' \
+	    >> "${tmpdir}/mid/_.vsm_mgt/_.index.new"
+	tail -n +3 "${tmpdir}/mid/_.vsm_mgt/_.index" \
+	    >> "${tmpdir}/mid/_.vsm_mgt/_.index.new"
+	mv "${tmpdir}/mid/_.vsm_mgt/_.index.new" \
+	    "${tmpdir}/mid/_.vsm_mgt/_.index"
+
+	# One reader run per case, kept for the assertions below.
+	for c in plus minus mid ; do
+		varnishstat -n "${tmpdir}/$c" -t 1 -1 \
+		    > "${tmpdir}/$c.out" 2> "${tmpdir}/$c.err" || true
+	done
+}
+
+# A '+' line with too many fields reports its line number and the counts.
+shell -expect "Malformed _.index line 1: 7 fields, expected 3 to 5" {
+	cat "${tmpdir}/plus.err"
+}
+
+# Splitting only happens on whitespace, so the message names that as the
+# cause of the extra fields.
+shell -expect "Whitespace in a segment name or ident" {
+	cat "${tmpdir}/plus.err"
+}
+
+# The '-' path reports the same way, here with too few fields.
+shell -expect "Malformed _.index line 1: 2 fields, expected 3 to 5" {
+	cat "${tmpdir}/minus.err"
+}
+
+# A bad line partway into the index is reported against its own line number.
+shell -expect "Malformed _.index line 3: 7 fields, expected 3 to 5" {
+	cat "${tmpdir}/mid.err"
+}
+
+# The reader publishes no counters, so a partial view of the index never
+# reaches a consumer.
+shell -expect "counters=0" {
+	echo "counters=$(grep -c '^MAIN\.' "${tmpdir}/mid.out" || true)"
+}

--- a/lib/libvinylapi/vsm.c
+++ b/lib/libvinylapi/vsm.c
@@ -127,6 +127,7 @@ struct vsm_set {
 
 	// _.index reading state
 	struct vlu		*vlu;
+	unsigned		lineno;
 	unsigned		retval;
 	struct vsm_seg		*vg;
 
@@ -532,6 +533,26 @@ vsm_vlu_hash(struct vsm_set *vs, const char *line)
 }
 
 static int
+vsm_bad_index(struct vsm *vd, const struct vsm_set *vs, const char *line,
+    int ac, const char *err)
+{
+
+	/* av[0] is VAV_Parse's error slot, so ac is one more than the
+	 * number of fields on the line
+	 */
+	if (err != NULL)
+		return (vsm_diag(vd, "Malformed _.index line %u: %s: %s",
+		    vs->lineno, err, line));
+	if (ac > 6)
+		return (vsm_diag(vd, "Malformed _.index line %u: %d fields, "
+		    "expected 3 to 5.  Whitespace in a segment name or ident "
+		    "splits it into extra fields: %s", vs->lineno, ac - 1,
+		    line));
+	return (vsm_diag(vd, "Malformed _.index line %u: %d fields, "
+	    "expected 3 to 5: %s", vs->lineno, ac - 1, line));
+}
+
+static int
 vsm_vlu_plus(struct vsm *vd, struct vsm_set *vs, const char *line)
 {
 	char **av;
@@ -541,8 +562,7 @@ vsm_vlu_plus(struct vsm *vd, struct vsm_set *vs, const char *line)
 	av = VAV_Parse(line + 1, &ac, 0);
 
 	if (av[0] != NULL || ac < 4 || ac > 6) {
-		(void)(vsm_diag(vd, "vsm_vlu_plus: bad index (%d/%s)",
-		    ac, av[0]));
+		(void)vsm_bad_index(vd, vs, line, ac, av[0]);
 		VAV_Free(av);
 		return (-1);
 	}
@@ -590,8 +610,7 @@ vsm_vlu_minus(struct vsm *vd, struct vsm_set *vs, const char *line)
 	av = VAV_Parse(line + 1, &ac, 0);
 
 	if (av[0] != NULL || ac < 4 || ac > 6) {
-		(void)(vsm_diag(vd, "vsm_vlu_minus: bad index (%d/%s)",
-		    ac, av[0]));
+		(void)vsm_bad_index(vd, vs, line, ac, av[0]);
 		VAV_Free(av);
 		return (-1);
 	}
@@ -626,6 +645,8 @@ vsm_vlu_func(void *priv, const char *line)
 	CHECK_OBJ_NOTNULL(vd, VSM_MAGIC);
 	AN(line);
 
+	vs->lineno++;
+
 	/* Up the serial counter. This wraps at UINTPTR_MAX/2
 	 * because thats the highest value we can store in struct
 	 * vsm_fantom. */
@@ -654,13 +675,21 @@ vsm_vlu_func(void *priv, const char *line)
 static void
 vsm_readlines(struct vsm_set *vs)
 {
+	struct vsm *vd;
 	int i;
+
+	vd = vs->vsm;
+	CHECK_OBJ_NOTNULL(vd, VSM_MAGIC);
 
 	do {
 		assert(vs->fd >= 0);
 		i = VLU_Fd(vs->vlu, vs->fd);
 	} while (!i);
-	assert(i == -2);
+	if (i != -2) {
+		/* The line handler left the reason in the diag */
+		AN(vd->diag);
+		WRONG(VSB_data(vd->diag));
+	}
 }
 
 static unsigned
@@ -718,6 +747,7 @@ vsm_refresh_set(struct vsm *vd, struct vsm_set *vs)
 		if (vs->fd < 0)
 			return (vs->retval | restarted);
 		VLU_Reset(vs->vlu);
+		vs->lineno = 0;
 		AZ(fstat(vs->fd, &vs->fst));
 		vsm_readlines(vs);
 		vsm_wash_set(vs, 0);


### PR DESCRIPTION
Backport of vinyl-cache [#4569](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4569).

`vsm_vlu_plus()`/`vsm_vlu_minus()` only reported a generic "bad index" message with no way to find which line in `_.index` was wrong. Track the current line number and report it, the field count against the expected range, and a hint when the likely cause is whitespace splitting a segment name into extra fields.

Part of the backport tracking list in #70.