### PR TITLE
[VinylTest] Detect strtoumax overflow via errno not return value

### DIFF
--- a/bin/vinyltest/tests/b00099.vtc
+++ b/bin/vinyltest/tests/b00099.vtc
@@ -1,0 +1,17 @@
+vtest "vinyltest -expect parses UINT64_MAX literal as a number"
+
+# Regression: -expect must accept the literal UINT64_MAX value
+# (0xffffffffffffffff) as a numeric operand. Probeless backends report
+# .happy with all probe-history bits set, i.e. 0xffffffffffffffff, so
+# this comparison is essential for real backend health-status tests.
+#
+# Before the fix, strtoumax()'s "u != UINTMAX_MAX" overflow check fired
+# both for real overflow AND legitimate UINTMAX_MAX inputs, misinterpreting
+# the digit string as a stat field name and failing with
+# "stats field <number> unknown".
+
+server s1 { } -start
+
+varnish v1 -vcl+backend { } -start
+
+varnish v1 -expect VBE.vcl1.s1.happy == 0xffffffffffffffff

--- a/bin/vinyltest/vtc_varnish.c
+++ b/bin/vinyltest/vtc_varnish.c
@@ -34,6 +34,7 @@
 
 #include <sys/socket.h>
 
+#include <errno.h>
 #include <fcntl.h>
 #include <fnmatch.h>
 #include <inttypes.h>
@@ -1037,8 +1038,9 @@ varnish_expect(struct varnish *v, char * const *av)
 	} else {
 		AN(av[1]);
 		AN(av[2]);
+		errno = 0;
 		u = strtoumax(av[2], &p, 0);
-		if (u != UINTMAX_MAX && *p == '\0')
+		if (errno != ERANGE && *p == '\0')
 			sp.rhs.val = u;
 		else
 			sp.rhs.pattern = av[2];

--- a/bin/vinyltest/vtc_vinyl.c
+++ b/bin/vinyltest/vtc_vinyl.c
@@ -34,6 +34,7 @@
 
 #include <sys/socket.h>
 
+#include <errno.h>
 #include <fcntl.h>
 #include <fnmatch.h>
 #include <inttypes.h>
@@ -1037,8 +1038,9 @@ vinyl_expect(struct vinyl *v, char * const *av)
 	} else {
 		AN(av[1]);
 		AN(av[2]);
+		errno = 0;
 		u = strtoumax(av[2], &p, 0);
-		if (u != UINTMAX_MAX && *p == '\0')
+		if (errno != ERANGE && *p == '\0')
 			sp.rhs.val = u;
 		else
 			sp.rhs.pattern = av[2];


### PR DESCRIPTION
Backport of vinyl-cache [#4517](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4517).

`-expect`'s numeric-literal parsing rejected the literal `UINT64_MAX` value, since `strtoumax()` also returns `UINTMAX_MAX` on real overflow and the old check (`u != UINTMAX_MAX`) couldn't tell the two apart. Check `errno == ERANGE` instead — probeless backends report `.happy` with all probe-history bits set (`0xffffffffffffffff`), so this comparison matters for real health-status tests.

Applied to both `vtc_vinyl.c` and `vtc_varnish.c` — this repo carries two near-duplicate command implementations, and only `vtc_varnish.c` is actually compiled (`bin/vinyltest/Makefile.am` only lists it as a source, under `-DVTEST_WITH_VTC_VARNISH`), which is what the new test exercises.

Part of the backport tracking list in #70.