### PR TITLE
vcc_expr: Minor cleanup

### DIFF
--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -49,7 +49,7 @@ struct expr {
 #define EXPR_VAR	(1<<0)
 #define EXPR_CONST	(1<<1)
 #define EXPR_STR_CONST	(1<<2)		// Last string elem is "..."
-	struct token	*t1, *t2;
+	struct token	*t;
 	struct symbol	*instance;
 	int		nstr;
 };
@@ -230,10 +230,7 @@ vcc_expr_edit(struct vcc *tl, vcc_type_t fmt, const char *p, struct expr *e1,
 		p++;
 	}
 	AZ(VSB_finish(e->vsb));
-	e->t1 = e1->t1;
-	e->t2 = e1->t2;
-	if (e2 != NULL)
-		e->t2 = e2->t2;
+	e->t = e1->t;
 	vcc_delete_expr(e1);
 	vcc_delete_expr(e2);
 	return (e);
@@ -318,7 +315,7 @@ vcc_expr_tostring(struct vcc *tl, struct expr **e)
 		VSB_printf(tl->sb,
 		    "Cannot convert %s to STRING.\n",
 		    vcc_utype((*e)->fmt));
-		vcc_ErrWhere2(tl, (*e)->t1, tl->t);
+		vcc_ErrWhere2(tl, (*e)->t, tl->t);
 	}
 }
 
@@ -882,7 +879,7 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			e1->constant |= EXPR_STR_CONST;
 			e1->nstr = 1;
 		}
-		e1->t1 = tl->t;
+		e1->t = tl->t;
 		e1->constant |= EXPR_CONST;
 		vcc_NextToken(tl);
 		*e = e1;
@@ -911,7 +908,7 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		VSB_printf(e1->vsb, "%s", tl->t->dec);
 		AZ(VSB_finish(e1->vsb));
 		e1->constant |= EXPR_STR_CONST;
-		e1->t1 = tl->t;
+		e1->t = tl->t;
 		vcc_NextToken(tl);
 		*e = e1;
 		return;


### PR DESCRIPTION
Backport of vinyl-cache [#4576](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4576).

`struct expr` had two token-pointer fields `t1`/`t2`, but `t2` was write-only (assigned in `vcc_expr_edit()`, never read anywhere) and `t1` alone already served every read site (`vcc_ErrWhere2()` is always called with a stored start token plus the current parse position, never two stored tokens). Consolidate into a single field `t`. Pure refactor, no behavior change.

Part of the backport tracking list in #70.