### PR TITLE
mgt: don't crash when the child fails to cool a discarded VCL

### DIFF
--- a/bin/vinyld/mgt/mgt_vcl.c
+++ b/bin/vinyld/mgt/mgt_vcl.c
@@ -697,8 +697,20 @@ mgt_vcl_discard(struct cli *cli, struct vclprog *vp)
 	if (mcf_is_label(vp)) {
 		AN(vp->warm);
 		vp->warm = 0;
-	} else {
-		(void)mgt_vcl_setstate(cli, vp, VCL_STATE_COLD);
+	} else if (mgt_vcl_setstate(cli, vp, VCL_STATE_COLD)) {
+		/*
+		 * Cooling cannot fail in the child, VCL_Poll() asserts as
+		 * much, so this is a CLI failure and MCH_Cli_Fail() has
+		 * signalled the child. The CLI being unusable is what matters
+		 * here: nothing can be told to the child, so finish the
+		 * discard as with none running.
+		 */
+		MGT_Complain(C_ERR,
+		    "VCL %s discarded after the child failed to cool it",
+		    vp->name);
+		VTAILQ_REMOVE(&discardhead, vp, discard_list);
+		mgt_vcl_del(vp);
+		return;
 	}
 	if (MCH_Running()) {
 		AZ(vp->warm);

--- a/bin/vinyltest/tests/v00077.vtc
+++ b/bin/vinyltest/tests/v00077.vtc
@@ -1,0 +1,61 @@
+vtest "vcl.discard when the child stops answering the CLI"
+
+# Discarding a VCL first cools it, and the cold event runs on the child's
+# CLI thread. A child that stalls there misses its cli_timeout and gets
+# killed, which must leave the manager able to report the failure and
+# restart the child, not assert on the state the VCL never reached.
+
+# A warm VCL that holds up the cold event for longer than cli_timeout.
+shell {
+	cat >${tmpdir}/f1 <<-EOF
+	vcl 4.1;
+
+	import debug;
+
+	backend default none;
+
+	sub vcl_init {
+		debug.cold_stall(10s);
+	}
+	EOF
+}
+
+# The kill below makes the child panic. no_coredump keeps the resulting
+# core out of the manager's exit status, and passing it as an argument also
+# avoids a real core where RLIMIT_CORE is honoured.
+#
+# cli_timeout has to stay above the round trips of the restart further down,
+# not just above the stall.
+varnish v1 -arg "-p feature=+no_coredump -p cli_timeout=3" -vcl {
+	backend default none;
+} -start
+
+varnish v1 -cliok "param.set auto_restart on"
+
+# Loaded warm, but not active, so that it can be discarded.
+varnish v1 -cliok "vcl.load stall ${tmpdir}/f1 warm"
+varnish v1 -cliexpect "warm *warm *0 *stall" "vcl.list"
+
+# The child never answers, so the manager kills it and the command fails.
+varnish v1 -clierr 400 "vcl.discard stall"
+
+# The manager survived, and the discard went through: the VCL is gone.
+varnish v1 -clierr 106 "vcl.discard stall"
+
+# auto_restart brings the child back. Being killed for CLI silence is a
+# panic by design, so the panic is expected here.
+delay 5
+varnish v1 -cliexpect "running" "status"
+
+# Surviving to reap the child is what makes its panic reportable:
+# mgt_panic_record() runs from mgt_reap_child(). The backtrace it carries
+# names the thread that stopped answering, but its format depends on the
+# available unwinder, so only the panic itself is asserted here.
+varnish v1 -cliexpect "It's time for the big quit" "panic.show"
+varnish v1 -cliok "panic.clear"
+
+# The discarded VCL is gone, and was not left stranded in the new child.
+varnish v1 -cliexpect "active *auto *warm *0 *vcl1" "vcl.list"
+varnish v1 -cliexpect ! "stall" "vcl.list"
+
+varnish v1 -expectexit 0x40

--- a/bin/vinyltest/tests/v00078.vtc
+++ b/bin/vinyltest/tests/v00078.vtc
@@ -1,0 +1,30 @@
+vtest "vcl.discard with no child running"
+
+# Cooling a VCL is a local operation when there is no child to tell:
+# mgt_vcl_askchild() sets the warm flag itself and reports success. This is
+# the behaviour a discard falls back on when the child has been killed for
+# not answering the CLI, see v00077.
+
+shell {
+	cat >${tmpdir}/f1 <<-EOF
+	vcl 4.1;
+	backend default none;
+	EOF
+}
+
+varnish v1 -vcl {
+	backend default none;
+} -start
+
+varnish v1 -cliok "vcl.load discardme ${tmpdir}/f1 warm"
+varnish v1 -cliexpect "warm *warm *0 *discardme" "vcl.list"
+
+varnish v1 -cliok "stop"
+varnish v1 -cliexpect "stopped" "status"
+
+varnish v1 -cliok "vcl.discard discardme"
+varnish v1 -clierr 106 "vcl.discard discardme"
+
+varnish v1 -cliok "start"
+varnish v1 -cliexpect "running" "status"
+varnish v1 -cliexpect "active *auto *warm *0 *vcl1" "vcl.list"

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -56,6 +56,7 @@ struct priv_vcl {
 	struct vclref		*vclref_discard;
 	struct vclref		*vclref_cold;
 	VCL_DURATION		vcl_discard_delay;
+	VCL_DURATION		cold_stall;
 	VCL_BACKEND		be;
 	unsigned		cold_be;
 	unsigned		cooling_be;
@@ -470,6 +471,9 @@ event_cold(VRT_CTX, const struct vmod_priv *priv)
 
 	VSL(SLT_Debug, NO_VXID, "%s: VCL_EVENT_COLD", VCL_Name(ctx->vcl));
 
+	if (priv_vcl->cold_stall > 0.0)
+		VTIM_sleep(priv_vcl->cold_stall);
+
 	VRT_DelDirector(&priv_vcl->be);
 
 	if (priv_vcl->cold_be) {
@@ -546,6 +550,17 @@ xyzzy_vcl_discard_delay(VRT_CTX, struct vmod_priv *priv, VCL_DURATION delay)
 	CAST_OBJ_NOTNULL(priv_vcl, priv->priv, PRIV_VCL_MAGIC);
 	assert(delay > 0.0);
 	priv_vcl->vcl_discard_delay = delay;
+}
+
+VCL_VOID v_matchproto_(td_debug_cold_stall)
+xyzzy_cold_stall(VRT_CTX, struct vmod_priv *priv, VCL_DURATION delay)
+{
+	struct priv_vcl *priv_vcl;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CAST_OBJ_NOTNULL(priv_vcl, priv->priv, PRIV_VCL_MAGIC);
+	assert(delay > 0.0);
+	priv_vcl->cold_stall = delay;
 }
 
 VCL_VOID v_matchproto_(td_debug_test_probe)

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -211,6 +211,11 @@ $Function VOID vcl_discard_delay(PRIV_VCL, DURATION)
 Hold a reference to the VCL when it goes cold preventing
 discard for the given delay.
 
+$Function VOID cold_stall(PRIV_VCL, DURATION)
+
+Sleep for the given delay in the cold event, on the CLI thread, so that the
+child misses its ``cli_timeout``.
+
 $Function ACL null_acl()
 
 Return no acl.


### PR DESCRIPTION
Backport of vinyl-cache [#4563](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4563).

`mgt_vcl_discard()` ignored `mgt_vcl_setstate()`'s return value when cooling a VCL before discarding it. If the child had already been killed for going silent on the CLI, the manager would then try to talk to it anyway (`MCH_Running()`/`mgt_cli_askchild()`) about a VCL state it never reached. Check the return value, complain, and finish the discard locally instead.

Adds `debug.cold_stall()` to simulate a child hanging during the cold event, for test coverage.

Part of the backport tracking list in #70.