### PR TITLE
[vinyladm] introduce "-x workdir"

### DIFF
--- a/bin/vinyladm/vinyladm.c
+++ b/bin/vinyladm/vinyladm.c
@@ -67,6 +67,7 @@
 #include "vapi/vsm.h"
 #include "vas.h"
 #include "vcli.h"
+#include "vin.h"
 #include "vjsn.h"
 #include "vtcp.h"
 
@@ -390,6 +391,8 @@ usage(int status)
 	fprintf(stderr,
 	    "Usage: varnishadm [-h] [-n workdir] [-p] [-S secretfile] "
 	    "[-T [address]:port] [-t timeout] [command [...]]\n");
+	fprintf(stderr,
+	    "       varnishadm [-n name] -x workdir\n");
 	fprintf(stderr, "\t-n is mutually exclusive with -S and -T\n");
 	exit(status);
 }
@@ -452,7 +455,7 @@ t_arg_timeout(const char *t_arg)
 	return (1);
 }
 
-#define OPTARG "hn:pS:T:t:"
+#define OPTARG "hn:pS:T:t:x:"
 
 int
 main(int argc, char * const *argv)
@@ -461,6 +464,7 @@ main(int argc, char * const *argv)
 	const char *S_arg = NULL;
 	const char *n_arg = NULL;
 	const char *t_arg = NULL;
+	char *wd;
 	int opt, sock;
 
 	if (argc == 2 && !strcmp(argv[1], "--optstring")) {
@@ -495,6 +499,21 @@ main(int argc, char * const *argv)
 		case 't':
 			t_arg = optarg;
 			break;
+		case 'x':
+			AN(optarg);
+			if (strcmp(optarg, "workdir")) {
+				fprintf(stderr, "Invalid -x argument\n");
+				usage(1);
+			}
+			if (argc != optind) {
+				fprintf(stderr, "-x workdir must be the last argument\n");
+				usage(1);
+			}
+			wd = VIN_n_Arg(n_arg);
+			AN(wd);
+			printf("%s\n", wd);
+			free(wd);
+			exit(0);
 		default:
 			usage(1);
 		}

--- a/bin/vinyladm/vinyladm.c
+++ b/bin/vinyladm/vinyladm.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2006 Verdens Gang AS
- * Copyright (c) 2006-2015 Varnish Software AS
+ * Copyright (c) 2006-2026 Varnish Software AS
  * All rights reserved.
  *
  * Author: Cecilie Fritzvold <cecilihf@linpro.no>

--- a/bin/vinyltest/tests/u00022.vtc
+++ b/bin/vinyltest/tests/u00022.vtc
@@ -1,0 +1,32 @@
+vtest "varnishadm -x workdir"
+
+# happy paths
+shell {
+    # -x workdir
+	DEFAULT_WORKDIR=$(varnishadm -x workdir)
+	test -n "$DEFAULT_WORKDIR"
+
+	# -x workdir foo: returns dirname(DEFAULT_WORKDIR)/foo
+	WORKDIR_FOO=$(varnishadm -n foo -x workdir)
+	EXPECTED_FOO=$(dirname "$DEFAULT_WORKDIR")/foo
+	test "$WORKDIR_FOO" = "$EXPECTED_FOO"
+
+	# -x workdir /foo: returns /foo
+	WORKDIR_ABSOLUTE=$(varnishadm -n /foo -x workdir)
+	test "$WORKDIR_ABSOLUTE" = "/foo"
+}
+
+# missing -x argument
+shell -exit 1 -match "option requires an argument -- 'x'" {
+	varnishadm -x
+}
+
+# -x with invalid argument fails
+shell -exit 1 -match "Invalid -x argument" {
+	varnishadm -x invalid
+}
+
+# -x workdir with too many arguments is rejected
+shell -exit 1 -match "-x workdir must be the last argument" {
+	varnishadm -x workdir arg1 arg2
+}

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -46,6 +46,9 @@ Varnish-Cache NEXT (unreleased)
 * A deficiency in HTTP/2 request parsing has been fixed by properly comparing
   pseudo-header names instead of doing a prefix match. (VSV00019_)
 
+* ``varnishadm -x workdir`` will print the default work directory and exit. This
+  is useful for tools that need to discover the VSM location in most setups.
+
 * ``ReqStart`` records in VSL gained a fourth field that will be either ``http``
   or ``https`` depending on whether TLS was used by the client. Thanks to this:
 


### PR DESCRIPTION
Backport of vinyl-cache [#4494](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4494).

Add a `-x workdir` option to `varnishadm` that prints the default/computed work directory (via `VIN_n_Arg()`) and exits, for tools that need to discover the VSM location without parsing `varnishd`'s own arguments.

Part of the backport tracking list in #70.