### PR TITLE
vut: add -0 argument to log/ncsa/hist/top

### DIFF
--- a/bin/vinylhist/vinylhist_options.h
+++ b/bin/vinylhist/vinylhist_options.h
@@ -70,6 +70,7 @@
 	    " > doubles."						\
 	    )
 
+VUT_OPT_0
 HIS_OPT_B
 VSL_OPT_C
 VUT_OPT_d

--- a/bin/vinyllog/vinyllog_options.h
+++ b/bin/vinyllog/vinyllog_options.h
@@ -65,6 +65,7 @@
 	    " and cannot work as a daemon."				\
 	)
 
+VUT_OPT_0
 LOG_OPT_a
 LOG_OPT_A
 VSL_OPT_b

--- a/bin/vinylncsa/vinylncsa_options.h
+++ b/bin/vinylncsa/vinylncsa_options.h
@@ -91,6 +91,7 @@
 	    " in combination with -j to write JSON logs."		\
 	)
 
+VUT_OPT_0
 NCSA_OPT_a
 NCSA_OPT_b
 NCSA_OPT_c

--- a/bin/vinyltop/vinyltop_options.h
+++ b/bin/vinyltop/vinyltop_options.h
@@ -62,6 +62,7 @@
 	    " This option has no effect if -1 option is also used."	\
 	)
 
+VUT_OPT_0
 TOP_OPT_1
 VSL_OPT_b
 VSL_OPT_c

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -43,6 +43,9 @@ Varnish-Cache NEXT (unreleased)
 
 .. _VSV00019: https://vinyl-cache.org/security/VSV00019.html
 
+* ``varnish{log,ncsa,hist,top}`` all gained the ``-0`` dry-run argument that
+  allows testing a command line before running it for real.
+
 * A deficiency in HTTP/2 request parsing has been fixed by properly comparing
   pseudo-header names instead of doing a prefix match. (VSV00019_)
 

--- a/include/vut.h
+++ b/include/vut.h
@@ -44,6 +44,7 @@ struct VUT {
 	const char	*progname;
 
 	/* Options */
+	int		dryrun_opt;
 	int		d_opt;
 	int		D_opt;
 	int		g_arg;

--- a/include/vut_options.h
+++ b/include/vut_options.h
@@ -46,6 +46,16 @@
 	    "Print version information and exit."			\
 	)
 
+#define VUT_OPT_0							\
+	VOPT("0", "[-0]", "Check configuration",			\
+	    "Return immediately (i.e. process 0 transactions) if the "	\
+	    "configuration is valid. This option means the process will "	\
+	    "not try to write a PID file, daemonize, connect to a VSM, "\
+	    "or open a log file, but it will run all the other "	\
+	    "pre-flight operation, including validating the VSL "	\
+	    "queries."							\
+	)
+
 #define VUT_OPT_d							\
 	VOPT("d", "[-d]", "Process old log entries and exit",		\
 	    "Process log records at the head of the log and exit."	\

--- a/lib/libvinylapi/vut.c
+++ b/lib/libvinylapi/vut.c
@@ -162,6 +162,9 @@ VUT_Arg(struct VUT *vut, int opt, const char *arg)
 	AN(opt);
 
 	switch (opt) {
+	case '0':
+		vut->dryrun_opt = 1;
+		return (1);
 	case 'd':
 		/* Head */
 		vut->d_opt = 1;
@@ -312,6 +315,9 @@ VUT_Setup(struct VUT *vut)
 		VUT_Error(vut, 1, "Query expression error:\n%s",
 		    VSL_Error(vut->vsl));
 
+	if (vut->dryrun_opt)
+		return;
+
 	/* Setup input */
 	if (vut->r_arg) {
 		c = VSL_CursorFile(vut->vsl, vut->r_arg, 0);
@@ -416,7 +422,7 @@ VUT_Main(struct VUT *vut)
 	CHECK_OBJ_NOTNULL(vut, VUT_MAGIC);
 	AN(vut->vslq);
 
-	while (!VSIG_int && !VSIG_term) {
+	while (!VSIG_int && !VSIG_term && !vut->dryrun_opt) {
 		if (VSIG_hup != vut->last_sighup) {
 			/* sighup callback */
 			vut->last_sighup = VSIG_hup;


### PR DESCRIPTION
Backport of vinyl-cache [#4493](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4493).

Add a shared `-0` dry-run flag to the VUT framework, wired into `varnishlog`/`varnishncsa`/`varnishhist`/`varnishtop`: validate configuration and the VSL query, then exit before connecting to a VSM or opening a log file, without processing any transactions.

Part of the backport tracking list in #70.