### PR TITLE
backend: add VSCs for backend errors

### DIFF
--- a/bin/vinyld/cache/cache.h
+++ b/bin/vinyld/cache/cache.h
@@ -95,7 +95,7 @@ struct stream_close {
 	const char		*desc;
 };
     extern const struct stream_close SC_NULL[1];
-#define SESS_CLOSE(nm, stat, err, desc) \
+#define SESS_CLOSE_C(nm, stat, err, desc) \
     extern const struct stream_close SC_##nm[1];
 #include "tbl/sess_close.h"
 

--- a/bin/vinyld/cache/cache_backend.c
+++ b/bin/vinyld/cache/cache_backend.c
@@ -212,8 +212,8 @@ vbe_close_acct(const struct pfd *pfd, struct VSC_vbe *vsc,
 		return;							\
 	}
 #include "tbl/sess_close.h"
-
-	WRONG("Wrong event in vbe_close_acct");
+	else
+		WRONG("Wrong event in vbe_close_acct");
 }
 
 static void v_matchproto_(vdi_finish_f)

--- a/bin/vinyld/cache/cache_backend.c
+++ b/bin/vinyld/cache/cache_backend.c
@@ -381,27 +381,28 @@ vbe_dir_getfd(VRT_CTX, struct worker *wrk, VCL_BACKEND dir, struct backend *bp,
 	bp->vsc->req++;
 	Lck_Unlock(bp->director->mtx);
 
+	INIT_OBJ(bo->htc, HTTP_CONN_MAGIC);
+	bo->htc->priv = pfd;
+	bo->htc->rfd = fdp;
+	bo->htc->oper = VCP_Get_Oper(pfd, &bo->htc->oper_priv);
+	AN(bo->htc->oper);
+	bo->htc->doclose = SC_NULL;
 	CHECK_OBJ_NOTNULL(bo->htc->doclose, STREAM_CLOSE_MAGIC);
 
 	err = 0;
 	if (bp->proxy_header != 0)
-		err += VPX_Send_Proxy(*fdp, bp->proxy_header, bo->sp);
+		err = VPX_Send_Proxy(*fdp, bp->proxy_header, bo->sp);
 	if (err < 0) {
 		VSLb(bo->vsl, SLT_FetchError,
 		     "backend %s: proxy write errno %d (%s)",
 		     VRT_BACKEND_string(dir),
 		     errno, VAS_errtxt(errno));
-		// account as if connect failed - good idea?
-		VSC_C_main->backend_fail++;
-		bo->htc = NULL;
-		VCP_Close(&pfd);
-		AZ(pfd);
+		bo->htc->doclose = SC_TX_ERROR;
 		Lck_Lock(bp->director->mtx);
-		bp->n_conn--;
-		bp->vsc->conn--;
+		VSC_C_main->backend_fail++;
 		bp->vsc->req--;
-		vbe_connwait_signal_locked(bp);
 		Lck_Unlock(bp->director->mtx);
+		vbe_dir_finish(ctx, dir);
 		vbe_connwait_fini(cw);
 		return (NULL);
 	}
@@ -419,12 +420,6 @@ vbe_dir_getfd(VRT_CTX, struct worker *wrk, VCL_BACKEND dir, struct backend *bp,
 		    PFD_Age(pfd), (uintmax_t)PFD_Reused(pfd));
 	}
 
-	INIT_OBJ(bo->htc, HTTP_CONN_MAGIC);
-	bo->htc->priv = pfd;
-	bo->htc->rfd = fdp;
-	bo->htc->oper = VCP_Get_Oper(pfd, &bo->htc->oper_priv);
-	AN(bo->htc->oper);
-	bo->htc->doclose = SC_NULL;
 	FIND_TMO(first_byte_timeout,
 	    bo->htc->first_byte_timeout, bo, bp);
 	FIND_TMO(between_bytes_timeout,

--- a/bin/vinyld/cache/cache_backend.c
+++ b/bin/vinyld/cache/cache_backend.c
@@ -183,6 +183,35 @@ vbe_connwait_fini(struct connwait *cw)
 }
 
 /*--------------------------------------------------------------------
+ * Update bc_ counters by reason (implementing ses_close_acct for backends)
+ *
+ * assuming that the approximation of non-atomic global counters is sufficient.
+ * if not: update to per-wrk
+ */
+
+static void
+vbe_close_acct(const struct pfd *pfd, const stream_close_t reason)
+{
+
+	if (reason == SC_NULL) {
+		assert(PFD_State(pfd) == PFD_STATE_USED);
+		VSC_C_main->bc_tx_proxy++;
+		return;
+	}
+
+#define SESS_CLOSE(U, l, err, desc)					\
+	if (reason == SC_ ## U) {					\
+		VSC_C_main->bc_ ## l++;					\
+		if (err)						\
+			VSC_C_main->backend_closed_err++;		\
+		return;							\
+	}
+#include "tbl/sess_close.h"
+
+	WRONG("Wrong event in vbe_close_acct");
+}
+
+/*--------------------------------------------------------------------
  * Get a connection to the backend
  *
  * note: wrk is a separate argument because it differs for pipe vs. fetch
@@ -378,11 +407,13 @@ vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 	pfd = bo->htc->priv;
 	bo->htc->priv = NULL;
 	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0) {
+		vbe_close_acct(pfd, bo->htc->doclose);
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s close %s", *PFD_Fd(pfd),
 		    VRT_BACKEND_string(d), bo->htc->doclose->name);
 		VCP_Close(&pfd);
 		AZ(pfd);
 		Lck_Lock(bp->director->mtx);
+		VSC_C_main->backend_closed++;
 	} else {
 		assert (PFD_State(pfd) == PFD_STATE_USED);
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s recycle", *PFD_Fd(pfd),

--- a/bin/vinyld/cache/cache_backend.c
+++ b/bin/vinyld/cache/cache_backend.c
@@ -190,20 +190,25 @@ vbe_connwait_fini(struct connwait *cw)
  */
 
 static void
-vbe_close_acct(const struct pfd *pfd, const stream_close_t reason)
+vbe_close_acct(const struct pfd *pfd, struct VSC_vbe *vsc,
+    const stream_close_t reason)
 {
 
 	if (reason == SC_NULL) {
 		assert(PFD_State(pfd) == PFD_STATE_USED);
 		VSC_C_main->bc_tx_proxy++;
+		vsc->tx_proxy++;
 		return;
 	}
 
 #define SESS_CLOSE(U, l, err, desc)					\
 	if (reason == SC_ ## U) {					\
 		VSC_C_main->bc_ ## l++;					\
-		if (err)						\
+		vsc->l++;						\
+		if (err) {						\
 			VSC_C_main->backend_closed_err++;		\
+			vsc->closed_err++;				\
+		}							\
 		return;							\
 	}
 #include "tbl/sess_close.h"
@@ -223,6 +228,7 @@ vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 	bo = ctx->bo;
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 	CAST_OBJ_NOTNULL(bp, d->priv, BACKEND_MAGIC);
+	AN(bp->vsc);
 
 	CHECK_OBJ_NOTNULL(bo->htc, HTTP_CONN_MAGIC);
 	CHECK_OBJ_NOTNULL(bo->htc->doclose, STREAM_CLOSE_MAGIC);
@@ -230,13 +236,14 @@ vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 	pfd = bo->htc->priv;
 	bo->htc->priv = NULL;
 	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0) {
-		vbe_close_acct(pfd, bo->htc->doclose);
+		vbe_close_acct(pfd, bp->vsc, bo->htc->doclose);
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s close %s", *PFD_Fd(pfd),
 		    VRT_BACKEND_string(d), bo->htc->doclose->name);
 		VCP_Close(&pfd);
 		AZ(pfd);
 		Lck_Lock(bp->director->mtx);
 		VSC_C_main->backend_closed++;
+		bp->vsc->closed++;
 	} else {
 		assert (PFD_State(pfd) == PFD_STATE_USED);
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s recycle", *PFD_Fd(pfd),

--- a/bin/vinyld/cache/cache_backend.c
+++ b/bin/vinyld/cache/cache_backend.c
@@ -211,6 +211,51 @@ vbe_close_acct(const struct pfd *pfd, const stream_close_t reason)
 	WRONG("Wrong event in vbe_close_acct");
 }
 
+static void v_matchproto_(vdi_finish_f)
+vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
+{
+	struct backend *bp;
+	struct busyobj *bo;
+	struct pfd *pfd;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+	bo = ctx->bo;
+	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
+	CAST_OBJ_NOTNULL(bp, d->priv, BACKEND_MAGIC);
+
+	CHECK_OBJ_NOTNULL(bo->htc, HTTP_CONN_MAGIC);
+	CHECK_OBJ_NOTNULL(bo->htc->doclose, STREAM_CLOSE_MAGIC);
+
+	pfd = bo->htc->priv;
+	bo->htc->priv = NULL;
+	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0) {
+		vbe_close_acct(pfd, bo->htc->doclose);
+		VSLb(bo->vsl, SLT_BackendClose, "%d %s close %s", *PFD_Fd(pfd),
+		    VRT_BACKEND_string(d), bo->htc->doclose->name);
+		VCP_Close(&pfd);
+		AZ(pfd);
+		Lck_Lock(bp->director->mtx);
+		VSC_C_main->backend_closed++;
+	} else {
+		assert (PFD_State(pfd) == PFD_STATE_USED);
+		VSLb(bo->vsl, SLT_BackendClose, "%d %s recycle", *PFD_Fd(pfd),
+		    VRT_BACKEND_string(d));
+		Lck_Lock(bp->director->mtx);
+		VSC_C_main->backend_recycle++;
+		VCP_Recycle(bo->wrk, &pfd);
+	}
+	assert(bp->n_conn > 0);
+	bp->n_conn--;
+	AN(bp->vsc);
+	bp->vsc->conn--;
+#define ACCT(foo)	bp->vsc->foo += bo->acct.foo;
+#include "tbl/acct_fields_bereq.h"
+	vbe_connwait_signal_locked(bp);
+	Lck_Unlock(bp->director->mtx);
+	bo->htc = NULL;
+}
+
 /*--------------------------------------------------------------------
  * Get a connection to the backend
  *
@@ -386,51 +431,6 @@ vbe_dir_getfd(VRT_CTX, struct worker *wrk, VCL_BACKEND dir, struct backend *bp,
 	    bo->htc->between_bytes_timeout, bo, bp);
 	vbe_connwait_fini(cw);
 	return (pfd);
-}
-
-static void v_matchproto_(vdi_finish_f)
-vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
-{
-	struct backend *bp;
-	struct busyobj *bo;
-	struct pfd *pfd;
-
-	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
-	bo = ctx->bo;
-	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
-	CAST_OBJ_NOTNULL(bp, d->priv, BACKEND_MAGIC);
-
-	CHECK_OBJ_NOTNULL(bo->htc, HTTP_CONN_MAGIC);
-	CHECK_OBJ_NOTNULL(bo->htc->doclose, STREAM_CLOSE_MAGIC);
-
-	pfd = bo->htc->priv;
-	bo->htc->priv = NULL;
-	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0) {
-		vbe_close_acct(pfd, bo->htc->doclose);
-		VSLb(bo->vsl, SLT_BackendClose, "%d %s close %s", *PFD_Fd(pfd),
-		    VRT_BACKEND_string(d), bo->htc->doclose->name);
-		VCP_Close(&pfd);
-		AZ(pfd);
-		Lck_Lock(bp->director->mtx);
-		VSC_C_main->backend_closed++;
-	} else {
-		assert (PFD_State(pfd) == PFD_STATE_USED);
-		VSLb(bo->vsl, SLT_BackendClose, "%d %s recycle", *PFD_Fd(pfd),
-		    VRT_BACKEND_string(d));
-		Lck_Lock(bp->director->mtx);
-		VSC_C_main->backend_recycle++;
-		VCP_Recycle(bo->wrk, &pfd);
-	}
-	assert(bp->n_conn > 0);
-	bp->n_conn--;
-	AN(bp->vsc);
-	bp->vsc->conn--;
-#define ACCT(foo)	bp->vsc->foo += bo->acct.foo;
-#include "tbl/acct_fields_bereq.h"
-	vbe_connwait_signal_locked(bp);
-	Lck_Unlock(bp->director->mtx);
-	bo->htc = NULL;
 }
 
 static int v_matchproto_(vdi_gethdrs_f)

--- a/bin/vinyld/cache/cache_session.c
+++ b/bin/vinyld/cache/cache_session.c
@@ -64,7 +64,7 @@ static const struct {
 
 enum sess_close {
 	SCE_NULL = 0,
-#define SESS_CLOSE(nm, stat, err, desc) SCE_##nm,
+#define SESS_CLOSE_C(nm, stat, err, desc) SCE_##nm,
 #include "tbl/sess_close.h"
 	SCE_MAX,
 };
@@ -77,7 +77,7 @@ const struct stream_close SC_NULL[1] = {{
 	.desc = "Not Closing",
 }};
 
-#define SESS_CLOSE(nm, stat, err, text) \
+#define SESS_CLOSE_C(nm, stat, err, text) \
 	const struct stream_close SC_##nm[1] = {{ \
 		.magic = STREAM_CLOSE_MAGIC, \
 		.idx = SCE_##nm, \
@@ -89,7 +89,7 @@ const struct stream_close SC_NULL[1] = {{
 
 static const stream_close_t sc_lookup[SCE_MAX] = {
 	[SCE_NULL] = SC_NULL,
-#define SESS_CLOSE(nm, stat, err, desc) \
+#define SESS_CLOSE_C(nm, stat, err, desc) \
 	[SCE_##nm] = SC_##nm,
 #include "tbl/sess_close.h"
 };
@@ -608,7 +608,7 @@ ses_close_acct(stream_close_t reason)
 
 	CHECK_OBJ_NOTNULL(reason, STREAM_CLOSE_MAGIC);
 	switch (reason->idx) {
-#define SESS_CLOSE(reason, stat, err, desc)		\
+#define SESS_CLOSE_C(reason, stat, err, desc)		\
 	case SCE_ ## reason:				\
 		VSC_C_main->sc_ ## stat++;		\
 		break;

--- a/bin/vinyld/http1/cache_http1_fetch.c
+++ b/bin/vinyld/http1/cache_http1_fetch.c
@@ -240,9 +240,9 @@ V1F_FetchRespHdr(struct busyobj *bo)
 			VSLb(bo->vsl, SLT_FetchError, "Received junk");
 			htc->doclose = SC_RX_JUNK;
 			break;
-		case HTC_S_CLOSE:
+		case HTC_S_EOF:
 			VSLb(bo->vsl, SLT_FetchError, "backend closed");
-			htc->doclose = SC_RESP_CLOSE;
+			htc->doclose = SC_REM_CLOSE;
 			break;
 		case HTC_S_TIMEOUT:
 			VSLb(bo->vsl, SLT_FetchError, "timeout");

--- a/bin/vinyld/proxy/cache_proxy_proto.c
+++ b/bin/vinyld/proxy/cache_proxy_proto.c
@@ -762,6 +762,11 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	r = write(fd, VSB_data(vsb), VSB_len(vsb));
 	VTCP_Assert(r);
 
+	if (DO_DEBUG(DBG_PROXY_ERROR)) {
+		errno = EINTR;
+		return (-1);
+	}
+
 	if (!DO_DEBUG(DBG_PROTOCOL))
 		return (r);
 

--- a/bin/vinyltest/tests/c00036.vtc
+++ b/bin/vinyltest/tests/c00036.vtc
@@ -27,7 +27,7 @@ logexpect l1 -v v1 -q "vxid == 1004" {
 
 	# purpose of this vtc: test the internal retry when the
 	# backend goes away on a keepalive TCP connection:
-	expect 0 1004 FetchError      {^HTC eof .Unexpected end of input.}
+	expect 0 1004 FetchError      {^backend closed}
 	expect 0 1004 BackendClose    {^\d+ s1}
 	expect 0 1004 Timestamp       {^Connected:}
 	expect 0 1004 BackendOpen     {^\d+ s1}
@@ -54,9 +54,9 @@ client c1 {
 
 varnish v1 -expect backend_retry == 1
 varnish v1 -expect MAIN.backend_closed == 1
-varnish v1 -expect MAIN.backend_closed_err == 1
-varnish v1 -expect MAIN.bc_rx_bad == 1
+varnish v1 -expect MAIN.backend_closed_err == 0
+varnish v1 -expect MAIN.bc_rx_bad == 0
 varnish v1 -expect MAIN.bc_rx_timeout == 0
-varnish v1 -expect MAIN.bc_rem_close == 0
+varnish v1 -expect MAIN.bc_rem_close == 1
 
 logexpect l1 -wait

--- a/bin/vinyltest/tests/c00036.vtc
+++ b/bin/vinyltest/tests/c00036.vtc
@@ -53,4 +53,10 @@ client c1 {
 } -run
 
 varnish v1 -expect backend_retry == 1
+varnish v1 -expect MAIN.backend_closed == 1
+varnish v1 -expect MAIN.backend_closed_err == 1
+varnish v1 -expect MAIN.bc_rx_bad == 1
+varnish v1 -expect MAIN.bc_rx_timeout == 0
+varnish v1 -expect MAIN.bc_rem_close == 0
+
 logexpect l1 -wait

--- a/bin/vinyltest/tests/o00007.vtc
+++ b/bin/vinyltest/tests/o00007.vtc
@@ -40,3 +40,11 @@ varnish v1 -expect MAIN.bc_tx_proxy == 0
 varnish v1 -expect VBE.vcl1.default.conn == 0
 varnish v1 -expect VBE.vcl1.default.req == 0
 varnish v1 -expect VBE.vcl1.default.fail == 0
+varnish v1 -expect VBE.vcl1.default.closed == 1
+varnish v1 -expect VBE.vcl1.default.closed_err == 1
+
+varnish v1 -expect VBE.vcl1.default.rx_bad == 0
+varnish v1 -expect VBE.vcl1.default.rem_close == 0
+varnish v1 -expect VBE.vcl1.default.rx_timeout == 0
+varnish v1 -expect VBE.vcl1.default.tx_error == 1
+varnish v1 -expect VBE.vcl1.default.tx_proxy == 0

--- a/bin/vinyltest/tests/o00007.vtc
+++ b/bin/vinyltest/tests/o00007.vtc
@@ -15,6 +15,7 @@ varnish v1 -cliok "param.set debug +proxy_error"
 logexpect l1 -v v1 {
 	expect * 1002 Timestamp {^Connected:}
 	expect * 1002 FetchError {^backend default: proxy write errno}
+	expect * 1002 BackendClose {default close TX_ERROR}
 } -start
 
 client c1 {
@@ -27,13 +28,13 @@ logexpect l1 -wait
 
 varnish v1 -expect MAIN.backend_conn == 1
 varnish v1 -expect MAIN.backend_req == 0
-varnish v1 -expect MAIN.backend_closed == 0
-varnish v1 -expect MAIN.backend_closed_err == 0
+varnish v1 -expect MAIN.backend_closed == 1
+varnish v1 -expect MAIN.backend_closed_err == 1
 
 varnish v1 -expect MAIN.bc_rx_bad == 0
 varnish v1 -expect MAIN.bc_rem_close == 0
 varnish v1 -expect MAIN.bc_rx_timeout == 0
-varnish v1 -expect MAIN.bc_tx_error == 0
+varnish v1 -expect MAIN.bc_tx_error == 1
 varnish v1 -expect MAIN.bc_tx_proxy == 0
 
 varnish v1 -expect VBE.vcl1.default.conn == 0

--- a/bin/vinyltest/tests/o00007.vtc
+++ b/bin/vinyltest/tests/o00007.vtc
@@ -1,0 +1,41 @@
+vtest "Failing to send proxy headers to backend"
+
+server s1 {} -start
+
+varnish v1 -vcl {
+	backend default {
+		.host = "${s1_addr}";
+		.port = "${s1_port}";
+		.proxy_header = 2;
+	}
+} -start
+
+varnish v1 -cliok "param.set debug +proxy_error"
+
+logexpect l1 -v v1 {
+	expect * 1002 Timestamp {^Connected:}
+	expect * 1002 FetchError {^backend default: proxy write errno}
+} -start
+
+client c1 {
+	txreq
+	rxresphdrs
+	expect resp.status == 503
+} -run
+
+logexpect l1 -wait
+
+varnish v1 -expect MAIN.backend_conn == 1
+varnish v1 -expect MAIN.backend_req == 0
+varnish v1 -expect MAIN.backend_closed == 0
+varnish v1 -expect MAIN.backend_closed_err == 0
+
+varnish v1 -expect MAIN.bc_rx_bad == 0
+varnish v1 -expect MAIN.bc_rem_close == 0
+varnish v1 -expect MAIN.bc_rx_timeout == 0
+varnish v1 -expect MAIN.bc_tx_error == 0
+varnish v1 -expect MAIN.bc_tx_proxy == 0
+
+varnish v1 -expect VBE.vcl1.default.conn == 0
+varnish v1 -expect VBE.vcl1.default.req == 0
+varnish v1 -expect VBE.vcl1.default.fail == 0

--- a/bin/vinyltest/tests/u00008.vtc
+++ b/bin/vinyltest/tests/u00008.vtc
@@ -71,9 +71,11 @@ process p1 -expect-text 4 124 "AVG_1000"
 process p1 -expect-text 22 108 "UNSEEN  DIAG"
 
 process p1 -key NPAGE
+process p1 -key NPAGE
 process p1 -expect-text 0 0 "VBE.vcl1.s1.helddown"
 process p1 -screen_dump
 
+process p1 -key PPAGE
 process p1 -key PPAGE
 process p1 -expect-text 0 0 "VBE.vcl1.s1.happy"
 process p1 -screen_dump

--- a/include/tbl/debug_bits.h
+++ b/include/tbl/debug_bits.h
@@ -52,6 +52,7 @@ DEBUG_BIT(PROCESSORS,		processors,	"Fetch/Deliver processors")
 DEBUG_BIT(PROTOCOL,		protocol,	"Protocol debugging")
 DEBUG_BIT(VCL_KEEP,		vcl_keep,	"Keep VCL C and so files")
 DEBUG_BIT(LCK,			lck,		"Additional lock statistics")
+DEBUG_BIT(PROXY_ERROR,		proxy_error,	"Proxy send error to backend")
 DEBUG_BIT(CLI_SHOW_SENSITIVE,	cli_show_sensitive, "Log sensitive commands")
 #undef DEBUG_BIT
 

--- a/include/tbl/sess_close.h
+++ b/include/tbl/sess_close.h
@@ -31,6 +31,10 @@
 
 /*lint -save -e525 -e539 */
 
+#ifdef SESS_CLOSE_C
+  #define SESS_CLOSE(nm, stat, err, desc) SESS_CLOSE_C(nm, stat, err, desc)
+#endif
+
 // stream_close_t	  sc_* stat	is_err	Description
 SESS_CLOSE(REM_CLOSE,	  rem_close,	0,	"Peer Closed")
 SESS_CLOSE(REQ_CLOSE,	  req_close,	0,	"Peer requested close")
@@ -40,18 +44,21 @@ SESS_CLOSE(RX_BODY,	  rx_body,	1,	"Failure receiving body")
 SESS_CLOSE(RX_JUNK,	  rx_junk,	1,	"Received junk data")
 SESS_CLOSE(RX_OVERFLOW,   rx_overflow,	1,	"Received buffer overflow")
 SESS_CLOSE(RX_TIMEOUT,	  rx_timeout,	1,	"Receive timeout")
-SESS_CLOSE(RX_CLOSE_IDLE, rx_close_idle,0,	"timeout_idle reached")
 SESS_CLOSE(TX_PIPE,	  tx_pipe,	0,	"Piped transaction")
 SESS_CLOSE(TX_ERROR,	  tx_error,	1,	"Error transaction")
 SESS_CLOSE(TX_EOF,	  tx_eof,	0,	"EOF transmission")
 SESS_CLOSE(RESP_CLOSE,	  resp_close,	0,	"Backend/VCL requested close")
 SESS_CLOSE(OVERLOAD,	  overload,	1,	"Out of some resource")
-SESS_CLOSE(PIPE_OVERFLOW, pipe_overflow,1,	"Session pipe overflow")
-SESS_CLOSE(RANGE_SHORT,   range_short,	1,	"Insufficient data for range")
-SESS_CLOSE(REQ_HTTP20,	  req_http20,	1,	"HTTP2 not accepted")
-SESS_CLOSE(VCL_FAILURE,	  vcl_failure,	1,	"VCL failure")
-SESS_CLOSE(RAPID_RESET,	  rapid_reset,  1,      "HTTP2 rapid reset")
-SESS_CLOSE(BANKRUPT,	  bankrupt,	1,      "HTTP2 credit bankruptcy")
+#ifdef SESS_CLOSE_C
+  SESS_CLOSE(RX_CLOSE_IDLE,	rx_close_idle,	0,	"timeout_idle reached")
+  SESS_CLOSE(PIPE_OVERFLOW,	pipe_overflow,	1,	"Session pipe overflow")
+  SESS_CLOSE(RANGE_SHORT,	range_short,	1,	"Insufficient data for range")
+  SESS_CLOSE(REQ_HTTP20,	req_http20,	1,	"HTTP2 not accepted")
+  SESS_CLOSE(VCL_FAILURE,	vcl_failure,	1,	"VCL failure")
+  SESS_CLOSE(RAPID_RESET,	rapid_reset,	1,	"HTTP2 rapid reset")
+  SESS_CLOSE(BANKRUPT,		bankrupt,	1,	"HTTP2 credit bankruptcy")
+  #undef SESS_CLOSE_C
+#endif
 #undef SESS_CLOSE
 
 /*lint -restore */

--- a/lib/libvsc/VSC_main.vsc
+++ b/lib/libvsc/VSC_main.vsc
@@ -211,6 +211,100 @@
 	The maximum time to wait in the queue is defined by the backend
 	wait_timeout property.
 
+.. vinyl_vsc:: backend_closed
+	:group: wrk
+	:oneliner:	Backend Closed
+
+.. vinyl_vsc:: backend_closed_err
+	:oneliner:	Backend Closed with error
+
+	Total number of backends closed with errors. See bc_* diag counters
+	for detailed breakdown
+
+.. vinyl_vsc:: bc_rem_close
+	:level:	diag
+	:oneliner:	Backend Close OK  REM_CLOSE
+
+	Number of backend closes with REM_CLOSE (Server Closed)
+
+.. vinyl_vsc:: bc_req_close
+	:level:	diag
+	:oneliner:	Backend Close OK  REQ_CLOSE
+
+	Number of backend closes with REQ_CLOSE (Server requested close)
+
+.. vinyl_vsc:: bc_req_http10
+	:level:	diag
+	:oneliner:	Backend Close Err REQ_HTTP10
+
+	Number of backend closes with Error REQ_HTTP10 (Proto < HTTP/1.1)
+
+.. vinyl_vsc:: bc_rx_bad
+	:level:	diag
+	:oneliner:	Backend Close Err RX_BAD
+
+	Number of backend closes with Error RX_BAD (Received bad req/resp)
+
+.. vinyl_vsc:: bc_rx_body
+	:level:	diag
+	:oneliner:	Backend Close Err RX_BODY
+
+	Number of backend closes with Error RX_BODY (Failure receiving request body)
+
+.. vinyl_vsc:: bc_rx_junk
+	:level:	diag
+	:oneliner:	Backend Close Err RX_JUNK
+
+	Number of backend closes with Error RX_JUNK (Received junk data)
+
+.. vinyl_vsc:: bc_rx_overflow
+	:level:	diag
+	:oneliner:	Backend Close Err RX_OVERFLOW
+
+	Number of backend closes with Error RX_OVERFLOW (Received buffer overflow)
+
+.. vinyl_vsc:: bc_rx_timeout
+	:level:	diag
+	:oneliner:	Backend Close Err RX_TIMEOUT
+
+	Number of backend closes with Error RX_TIMEOUT (Receive timeout)
+
+.. vinyl_vsc:: bc_tx_proxy
+	:level:	diag
+	:oneliner:	Backend Close OK  TX_PROXY
+
+	Number of backend closes with TX_PROXY (Proxy transaction).
+
+.. vinyl_vsc:: bc_tx_pipe
+	:level:	diag
+	:oneliner:	Backend Close OK  TX_PIPE
+
+	Number of backend closes with TX_PIPE (Piped transaction)
+
+.. vinyl_vsc:: bc_tx_error
+	:level:	diag
+	:oneliner:	Backend Close Err TX_ERROR
+
+	Number of backend closes with Error TX_ERROR (Error transaction)
+
+.. vinyl_vsc:: bc_tx_eof
+	:level:	diag
+	:oneliner:	Backend Close OK  TX_EOF
+
+	Number of backend closes with TX_EOF (EOF transmission)
+
+.. vinyl_vsc:: bc_resp_close
+	:level:	diag
+	:oneliner:	Backend Close OK  RESP_CLOSE
+
+	Number of backend closes with RESP_CLOSE (Backend/VCL requested close)
+
+.. vinyl_vsc:: bc_overload
+	:level:	diag
+	:oneliner:	Backend Close Err OVERLOAD
+
+	Number of backend closes with Error OVERLOAD (Out of some resource)
+
 .. vinyl_vsc:: fetch_head
 	:group: wrk
 	:oneliner:	Fetch no body (HEAD)

--- a/lib/libvsc/VSC_vbe.vsc
+++ b/lib/libvsc/VSC_vbe.vsc
@@ -104,6 +104,86 @@
 
 	Number of times the max_connections limit was reached
 
+.. vinyl_vsc:: closed
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed
+
+.. vinyl_vsc:: closed_err
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed with error
+
+.. vinyl_vsc:: rem_close
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed by backend
+
+.. vinyl_vsc:: req_close
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closure requested by backend
+
+.. vinyl_vsc:: req_http10
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for proto < HTTP/1.1
+
+.. vinyl_vsc:: rx_bad
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for received bad response
+
+.. vinyl_vsc:: rx_body
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for failed receiving request body
+
+.. vinyl_vsc:: rx_junk
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for received junk data
+
+.. vinyl_vsc:: rx_overflow
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for receive buffer overflow
+
+.. vinyl_vsc:: rx_timeout
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for receive timeout
+
+.. vinyl_vsc:: tx_proxy
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for proxy transaction
+
+.. vinyl_vsc:: tx_pipe
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for piped transaction
+
+.. vinyl_vsc:: tx_error
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for error transaction
+
+.. vinyl_vsc:: tx_eof
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for EOF transmission
+
+.. vinyl_vsc:: resp_close
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for backend/VCL requested close
+
+.. vinyl_vsc:: overload
+	:type:	counter
+	:level: info
+	:oneliner:	Connection closed for out of some resource
+
 ..
 	=== Anything below is actually per VCP entry, but collected per
 	=== backend for simplicity


### PR DESCRIPTION
Backport of vinyl-cache [#4337](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4337).

Backends closed with no per-reason breakdown, only a single opaque `backend_fail`/`backend_recycle` pair. Adds `backend_closed`/`backend_closed_err` plus per-reason `bc_*` counters (`VSC_C_main`) and matching per-backend counters (`VSC_vbe`), via a shared `vbe_close_acct()` used by both the normal close path and a proxy-header-send failure.

Preserved as 8 separate commits, matching the real upstream history, cherry-picked directly from the `vinyl` remote (not hand-reconstructed) with original authorship, `Co-authored-by` trailers, and links to each upstream commit — mostly Asad Sajjad Ahmed's incremental work, plus a small Flexelint polish from Nils Goroll.

Along the way: fixes a dead switch case in `V1F_FetchRespHdr()` that matched the unused `HTC_S_CLOSE` value (already marked `// unused?` in this repo's own `tbl/htc.h`) instead of the `HTC_S_EOF` value `HTC_RxStuff()` actually returns there — confirmed by the actual upstream commit message: "Since RxStuff() no longer reports HTC_S_CLOSE we can reuse it for EOF." Also adds a `debug.+proxy_error` knob to simulate a proxy-send failure for testing.

This repo carries a downstream-only `bo->htc->oper`/`oper_priv` pair (via `VCP_Get_Oper()`) not present upstream — moved along with the relocated `INIT_OBJ`/`priv`/`rfd`/`doclose` block in the "minor refractory" commit, since it must run after `INIT_OBJ` zeroes the struct; verified nothing between that point and the proxy-send attempt depends on it, it's only read later during actual fetch/read.

Part of the backport tracking list in #70.