### PR TITLE
cache_http: Tighten accepted white space

### DIFF
--- a/bin/vinyld/cache/cache_http.c
+++ b/bin/vinyld/cache/cache_http.c
@@ -881,7 +881,7 @@ http_GetContentLength(const struct http *hp)
 	cl = VNUM_uint(b, NULL, &b);
 	if (cl < 0)
 		return (-2);
-	while (vct_islws(*b))
+	while (vct_isows(*b))
 		b++;
 	if (*b != '\0')
 		return (-2);
@@ -937,7 +937,7 @@ http_GetContentRange(const struct http *hp, ssize_t *lo, ssize_t *hi)
 		if (cl <= 0)
 			return (-2);
 	}
-	while (vct_islws(*b))
+	while (vct_isows(*b))
 		b++;
 	if (*b != '\0')
 		return (-2);
@@ -992,7 +992,7 @@ http_GetRange(const struct http *hp, ssize_t *lo, ssize_t *hi, ssize_t len)
 	if (*hi >= 0 && *hi < *lo)
 		return ("high smaller than low");
 
-	while (vct_islws(*b))
+	while (vct_isows(*b))
 		b++;
 	if (*b != '\0')
 		return ("Trailing stuff");


### PR DESCRIPTION
Backport of vinyl-cache [#4583](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4583).

`http_GetContentLength()`/`http_GetContentRange()`/`http_GetRange()` accepted any linear whitespace (LWS, RFC 7230, includes bare CRLF) after the parsed numeric value, instead of just optional whitespace (OWS, RFC 9110: space and tab). Use `vct_isows()` instead of `vct_islws()` in these 3 functions.

Part of the backport tracking list in #70.