### PR TITLE
Fix u00022.vtc: getopt's missing-argument message isn't portable

### DIFF
--- a/bin/vinyltest/tests/u00022.vtc
+++ b/bin/vinyltest/tests/u00022.vtc
@@ -17,7 +17,9 @@ shell {
 }
 
 # missing -x argument
-shell -exit 1 -match "option requires an argument -- 'x'" {
+# NB: getopt's exact wording differs across libcs (glibc/musl/BSD), so only
+# match the portable common substring.
+shell -exit 1 -match "requires an argument" {
 	varnishadm -x
 }
 


### PR DESCRIPTION
CI failure follow-up from #88: alpine-latest-arm and macos-x86 runs failed on `tests/u00022.vtc` (https://github.com/varnish/varnish/actions/runs/33569362301).

`glibc` says `option requires an argument -- 'x'`, musl (Alpine) says `option requires an argument: x`, and BSD libc (macOS) apparently differs again — the exact wording isn't portable across libcs. Match the common substring `requires an argument` instead. The other two `-match` checks in this test (`Invalid -x argument`, `-x workdir must be the last argument`) are our own literal strings from `varnishadm`'s own code, not libc's, so they're unaffected.