### PR TITLE
ci: fix push trigger to match branch names with slashes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Compile and Check
 on:
   push:
     branches:
-      - "*"
+      - "**"
     tags:
       - varnish-*
   workflow_dispatch:


### PR DESCRIPTION
GitHub Actions branch filters use single-level glob matching: `*` does not match `/`. Every branch pushed to this repo with a slash in its name (`backport/*`, `fix/*`, etc.) has therefore never triggered "Compile and Check" on push — only merges to `main` (no slash) did. In practice this means CI failures only ever surfaced *after* merge, never on the PR branch itself before merging.

Confirmed by checking `headBranch` on the last 100 workflow runs: every non-`main` branch that ever triggered a run has no slash in its name (`doc-fixes`, `dup_synth`, `9.0`, etc.) — none of the slash-named branches do.

Use `**` instead of `*` to match slashes too.

Found while investigating why #94 didn't get a CI run (had to trigger it manually via `workflow_dispatch` instead: https://github.com/varnish/varnish/actions/runs/33652663858).