### PR TITLE
ci: parallelize make dist

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           ./autogen.sh
           ./configure
-          make dist
+          make -j dist
 
       - name: Upload tarball
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Use \`make -j dist\` instead of \`make dist\` to build the distribution tarball in parallel.