### PR TITLE
-x json parameter

### DIFF
--- a/bin/vinyld/mgt/mgt.h
+++ b/bin/vinyld/mgt/mgt.h
@@ -197,6 +197,7 @@ void MCF_ParamConf(enum mcf_which_e, const char *param, const char *, ...)
 void MCF_ParamSet(struct cli *, const char *param, const char *val);
 void MCF_ParamProtect(struct cli *, const char *arg);
 void MCF_DumpRstParam(void);
+void MCF_DumpJsonParam(void);
 extern struct params mgt_param;
 
 /* mgt_shmem.c */

--- a/bin/vinyld/mgt/mgt_main.c
+++ b/bin/vinyld/mgt/mgt_main.c
@@ -142,7 +142,8 @@ usage(void)
 
 	printf("\nDocumentation options:\n");
 	printf(FMT, "-?", "Prints this usage message");
-	printf(FMT, "-x parameter", "Parameter documentation");
+	printf(FMT, "-x parameter", "Parameter documentation in RST format");
+	printf(FMT, "-x parameter-json", "Parameter documentation in JSON format");
 	printf(FMT, "-x vsl", "VSL record documentation");
 	printf(FMT, "-x cli", "CLI command documentation");
 	printf(FMT, "-x builtin", "Builtin VCL program");
@@ -383,6 +384,8 @@ mgt_x_arg(const char *x_arg)
 {
 	if (!strcmp(x_arg, "parameter"))
 		MCF_DumpRstParam();
+	else if (!strcmp(x_arg, "parameter-json"))
+		MCF_DumpJsonParam();
 	else if (!strcmp(x_arg, "vsl"))
 		mgt_DumpRstVsl();
 	else if (!strcmp(x_arg, "cli"))

--- a/bin/vinyltest/tests/u00024.vtc
+++ b/bin/vinyltest/tests/u00024.vtc
@@ -1,0 +1,25 @@
+vtest "varnishd -x parameter-json produces valid, well-shaped JSON"
+
+feature cmd "jq -V"
+
+shell {
+	set -e
+	varnishd -x parameter-json > result.json
+
+	jq '
+		type == "object" or error("top-level value is not an object"),
+		has("deprecated_dummy") == false or error("deprecated_dummy should not be present"),
+
+		.first_byte_timeout.units == "seconds" or error("first_byte_timeout: wrong units"),
+		.first_byte_timeout.default == "60.000" or error("first_byte_timeout: wrong default"),
+		.first_byte_timeout.minimum == "0.000" or error("first_byte_timeout: wrong minimum"),
+		(.first_byte_timeout | has("maximum")) == false or error("first_byte_timeout: unexpected maximum"),
+		(.first_byte_timeout.flags | index("timeout")) != null or error("first_byte_timeout: missing timeout flag"),
+		(.first_byte_timeout.description | type) == "string" or error("first_byte_timeout: missing description"),
+
+		.auto_restart.units == "bool" or error("auto_restart: wrong units"),
+		.auto_restart.default == "on" or error("auto_restart: wrong default"),
+		(.auto_restart | has("minimum")) == false or error("auto_restart: unexpected minimum"),
+		(.auto_restart | has("flags")) == false or error("auto_restart: unexpected flags")
+	' result.json
+}


### PR DESCRIPTION
Backport of vinyl-cache [#4378](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4378).

Add \`varnishd -x parameter-json\`, dumping all runtime parameters as JSON (alongside the existing \`-x parameter\` RST-format dump).

**First of a 3-PR chain** (tracked in #70): #4535 adds test coverage for this, #4540 fixes a typo introduced here (\`"smust_reload"\` → \`"must_reload"\`) — both must land after this one, in order. The typo is intentionally left as-is in this PR to match what upstream actually shipped at this point in their history.

Part of the backport tracking list in #70.