### PR TITLE
cache_req{,_fsm}: Add resp.storage control over synth body's storage

### DIFF
--- a/bin/vinyld/cache/cache_req.c
+++ b/bin/vinyld/cache/cache_req.c
@@ -40,8 +40,10 @@
 #include "cache_vinyld.h"
 #include "cache_conn_oper.h"
 #include "cache_filter.h"
+#include "cache_objhead.h"
 #include "cache_pool.h"
 #include "cache_transport.h"
+#include "storage/storage.h"		// stv_default
 
 #include "common/heritage.h"
 #include "tls/cache_tls.h"
@@ -340,6 +342,39 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 
 	VDP_Fini(req->vdc);
 }
+
+/*----------------------------------------------------------------------
+ * response body for vcl_synth {}
+ */
+
+static void
+resp_u_storage(struct req *req)
+{
+
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	HSH_DerefBoc(req->wrk, req->objcore);
+	(void)HSH_DerefObjCore(req->wrk, &req->objcore);
+}
+
+int
+Resp_l_storage(struct req *req, const struct stevedore *stv)
+{
+	int r;
+
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	CHECK_OBJ_NOTNULL(stv, STEVEDORE_MAGIC);
+
+	if (req->objcore != NULL)
+		resp_u_storage(req);
+	AZ(req->objcore);
+	req->objcore = HSH_Private(req->wrk);
+	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
+	r = STV_NewObject(req->wrk, req->objcore, stv, 0);
+	if (r == 0)
+		resp_u_storage(req);
+	return (r);
+}
+
 
 /*----------------------------------------------------------------------
  */

--- a/bin/vinyld/cache/cache_req_fsm.c
+++ b/bin/vinyld/cache/cache_req_fsm.c
@@ -382,11 +382,11 @@ cnt_synth(struct worker *wrk, struct req *req)
 
 	/* Discard any lingering request body before delivery */
 	(void)VRB_Ignore(req);
-
-	req->objcore = HSH_Private(wrk);
-	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
 	szl = -1;
-	if (STV_NewObject(wrk, req->objcore, stv_transient, 0)) {
+
+	if (req->objcore != NULL ||
+	    Resp_l_storage(req, stv_transient)) {
+		CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
 		body = VSB_data(synth_body);
 		szl = VSB_len(synth_body);
 		assert(szl >= 0);
@@ -407,14 +407,16 @@ cnt_synth(struct worker *wrk, struct req *req)
 
 	if (szl >= 0)
 		AZ(ObjSetU64(wrk, req->objcore, OA_LEN, VSB_len(synth_body)));
-	HSH_DerefBoc(wrk, req->objcore);
+	if (req->objcore != NULL)
+		HSH_DerefBoc(wrk, req->objcore);
 	VSB_destroy(&synth_body);
 
 	if (szl < 0) {
 		VSLb(req->vsl, SLT_Error, "Could not get storage");
 		req->doclose = SC_OVERLOAD;
 		VSLb_ts_req(req, "Resp", W_TIM_real(wrk));
-		(void)HSH_DerefObjCore(wrk, &req->objcore);
+		if (req->objcore != NULL)
+			(void)HSH_DerefObjCore(wrk, &req->objcore);
 		http_Teardown(req->resp);
 		return (REQ_FSM_DONE);
 	}

--- a/bin/vinyld/cache/cache_vinyld.h
+++ b/bin/vinyld/cache/cache_vinyld.h
@@ -435,6 +435,7 @@ void Req_Fail(struct req *req, stream_close_t reason);
 void Req_AcctLogCharge(struct VSC_main_wrk *, struct req *);
 void Req_LogHit(struct worker *, struct req *, struct objcore *, intmax_t);
 const char *Req_LogStart(const struct worker *, struct req *);
+int Resp_l_storage(struct req *req, const struct stevedore *stv);
 
 /* cache_req_body.c */
 int VRB_Ignore(struct req *);

--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -37,6 +37,7 @@
 #include "cache_vinyld.h"
 #include "cache_objhead.h"
 #include "cache_transport.h"
+#include "storage/storage.h"
 #include "common/heritage.h"
 
 #include "vcl.h"
@@ -439,6 +440,34 @@ VRT_l_req_storage(VRT_CTX, VCL_STEVEDORE stv)
 /*--------------------------------------------------------------------*/
 
 VCL_STEVEDORE
+VRT_r_resp_storage(VRT_CTX)
+{
+	struct objcore *oc;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+	oc = ctx->req->objcore;
+	if (oc == NULL)
+		VRT_l_resp_storage(ctx, NULL);
+	oc = ctx->req->objcore;
+	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+	return (oc->stobj->stevedore);
+}
+
+VCL_VOID
+VRT_l_resp_storage(VRT_CTX, VCL_STEVEDORE stv)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	if (stv == NULL)
+		stv = stv_transient;
+	if (! Resp_l_storage(ctx->req, stv))
+		VRT_fail(ctx, "Storage %s failed", stv->vclname);
+}
+
+/*--------------------------------------------------------------------*/
+
+VCL_STEVEDORE
 VRT_r_beresp_storage(VRT_CTX)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
@@ -457,8 +486,6 @@ VRT_l_beresp_storage(VRT_CTX, VCL_STEVEDORE stv)
 /*--------------------------------------------------------------------
  * VCL <= 4.0 ONLY
  */
-
-#include "storage/storage.h"
 
 /*--------------------------------------------------------------------*/
 

--- a/bin/vinyltest/tests/b00017.vtc
+++ b/bin/vinyltest/tests/b00017.vtc
@@ -1,6 +1,6 @@
-vtest "Check set resp.body in vcl_synth"
+vtest "Check set resp.body & storage in vcl_synth"
 
-varnish v1 -arg "-sTransient=debug,lessspace" -vcl {
+varnish v1 -arg "-sTransient=debug,lessspace -smalloc=malloc" -vcl {
 	backend foo {
 		.host = "${bad_backend}";
 	}
@@ -9,7 +9,11 @@ varnish v1 -arg "-sTransient=debug,lessspace" -vcl {
 	}
 
 	sub vcl_synth {
+		if (req.http.malloc) {
+			set resp.storage = storage.malloc;
+		}
 		set resp.body = "Custom vcl_synth's body";
+		set resp.http.storage = resp.storage;
 		return (deliver);
 	}
 } -start
@@ -21,6 +25,15 @@ client c1 {
 	expect resp.http.connection != close
 	expect resp.bodylen == 23
 	expect resp.body == "Custom vcl_synth's body"
+	expect resp.http.storage == "storage.Transient"
+
+	txreq -url "/" -hdr "malloc: true"
+	rxresp
+	expect resp.status == 888
+	expect resp.http.connection != close
+	expect resp.bodylen == 23
+	expect resp.body == "Custom vcl_synth's body"
+	expect resp.http.storage == "storage.malloc"
 } -run
 
-varnish v1 -expect s_synth == 1
+varnish v1 -expect s_synth == 2

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1970,6 +1970,26 @@ resp.status
 	modified based on that comparison, a 304 is sent.
 
 
+.. _resp.storage:
+
+resp.storage
+
+	Type: STEVEDORE
+
+	Readable from: vcl_synth
+
+	Writable from: vcl_synth
+
+
+	The storage backend to use for the synthetic response created in
+	vcl_synth.
+
+..      TODO
+..	Changing resp.storage deletes any synthetic body data as if ``unset
+..	resp.body`` had been called.
+
+	Defaults to storage.Transient
+
 .. _resp.time:
 
 resp.time


### PR DESCRIPTION
Backport of vinyl-cache [#4358](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4358).

Add \`resp.storage\`, settable in \`vcl_synth\`, to choose which stevedore backs a synthetic response instead of always \`stv_transient\`.

**First of a 6-PR chain** (tracked in #70): #4492 makes \`storage.Synth\` the default, #4500 fixes a null deref in \`VRT_r_resp_storage\`, #4365 adds a special-purpose synth storage engine — all hard-ordered after this one. #4495/#4269 touch the same hotspot files and land in this chain too, softly ordered.

**Flagged for reviewer awareness, not altered here** (confirmed present in upstream's own merged commit, not introduced by this backport): \`VRT_r_resp_storage()\` calls \`VRT_l_resp_storage(ctx, NULL)\` internally when \`resp.storage\` is read before ever being set, but doesn't check \`ctx->vpi->handling\` for \`VCL_RET_FAIL\` afterward — if that inner storage allocation fails, \`ctx->req->objcore\` stays NULL and the following \`CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC)\` would panic instead of gracefully propagating the VCL failure. This is upstream's own shipped logic (verified via their merge commit \`7ad0a0df7923\`), left as-is to stay faithful to what's actually merged upstream.

Part of the backport tracking list in #70.