### PR TITLE
add x parameter-json test

### DIFF
--- a/bin/vinyltest/tests/u00024.vtc
+++ b/bin/vinyltest/tests/u00024.vtc
@@ -1,0 +1,25 @@
+vtest "varnishd -x parameter-json produces valid, well-shaped JSON"
+
+feature cmd "jq -V"
+
+shell {
+	set -e
+	varnishd -x parameter-json > result.json
+
+	jq '
+		type == "object" or error("top-level value is not an object"),
+		has("deprecated_dummy") == false or error("deprecated_dummy should not be present"),
+
+		.first_byte_timeout.units == "seconds" or error("first_byte_timeout: wrong units"),
+		.first_byte_timeout.default == "60.000" or error("first_byte_timeout: wrong default"),
+		.first_byte_timeout.minimum == "0.000" or error("first_byte_timeout: wrong minimum"),
+		(.first_byte_timeout | has("maximum")) == false or error("first_byte_timeout: unexpected maximum"),
+		(.first_byte_timeout.flags | index("timeout")) != null or error("first_byte_timeout: missing timeout flag"),
+		(.first_byte_timeout.description | type) == "string" or error("first_byte_timeout: missing description"),
+
+		.auto_restart.units == "bool" or error("auto_restart: wrong units"),
+		.auto_restart.default == "on" or error("auto_restart: wrong default"),
+		(.auto_restart | has("minimum")) == false or error("auto_restart: unexpected minimum"),
+		(.auto_restart | has("flags")) == false or error("auto_restart: unexpected flags")
+	' result.json
+}


### PR DESCRIPTION
Backport of vinyl-cache [#4535](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4535).

Test coverage for #4378's \`-x parameter-json\`. Stacked on that PR (base branch set accordingly) — depends on it, second of the 3-PR JSON-parameter chain tracked in #70.

Confirmed the test's literal \`"60.000"\`/\`"0.000"\` expectations for \`first_byte_timeout\` are correct even though \`include/tbl/params.h\` defines it with bare \`"60"\`/\`"0"\`: \`MCF_InitParams()\` washes every param's min/max/default through its tweak function at \`varnishd\` startup (before \`-x\` argument dispatch), which normalizes timeout values to 3 decimal places.

Part of the backport tracking list in #70.