### PR TITLE
esi: Add VCL override for esi_include_onerror

### DIFF
--- a/bin/vinyld/cache/cache_esi_deliver.c
+++ b/bin/vinyld/cache/cache_esi_deliver.c
@@ -389,7 +389,7 @@ ved_vdp_esi_bytes(struct vdp_ctx *vdc, enum vdp_action act, void **priv,
 				break;
 			case VEC_IA:
 				ecx->abrt =
-				    FEATURE(FEATURE_ESI_INCLUDE_ONERROR);
+				    ecx->preq->esi_include_onerror;
 				/* FALLTHROUGH */
 			case VEC_IC:
 				ecx->p++;

--- a/bin/vinyld/cache/cache_req_fsm.c
+++ b/bin/vinyld/cache/cache_req_fsm.c
@@ -233,6 +233,8 @@ cnt_deliver(struct worker *wrk, struct req *req)
 	    !(req->objcore->flags & OC_F_PRIVATE))
 		http_ForceHeader(req->resp, H_Accept_Ranges, "bytes");
 
+	req->esi_include_onerror = FEATURE(FEATURE_ESI_INCLUDE_ONERROR);
+
 	req->t_resp = W_TIM_real(wrk);
 	VCL_deliver_method(req->vcl, wrk, req, NULL, NULL);
 

--- a/bin/vinyltest/tests/e00035.vtc
+++ b/bin/vinyltest/tests/e00035.vtc
@@ -70,3 +70,24 @@ client c1 {
 	rxresp
 	expect resp.body == "before  after"
 } -run
+
+varnish v1 -cliok "param.set feature -esi_include_onerror"
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.do_esi = beresp.http.surrogate-control ~ "ESI/1.0";
+		unset beresp.http.surrogate-control;
+	}
+	sub vcl_deliver {
+		set resp.esi_include_onerror = true;
+	}
+}
+
+server s1 {
+	# /continue already in cache
+	rxreq
+	expect req.url == "/err"
+	txresp -hdr "content-length: 100"
+	delay 0.1
+} -start
+
+client c1 -run

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1835,6 +1835,22 @@ resp.do_esi	``VCL >= 4.1``
 	It is a VCL error to use resp.do_esi after setting resp.filters.
 
 
+resp.esi_include_onerror
+
+	Type: BOOL
+
+	Readable from: vcl_deliver
+
+	Writable from: vcl_deliver
+
+	Defines whether the ``onerror="continue"`` attribute is needed to
+	resume the delivery of an ESI sub-request when the response status
+	is neither 200 nor 204.
+
+	Defaults to the setting of the ``feature esi_include_onerror``
+	parameter before entering ``vcl_deliver``, see :ref:`varnishd(1)`.
+
+
 .. _resp.filters:
 
 resp.filters

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1834,6 +1834,7 @@ resp.do_esi	``VCL >= 4.1``
 
 	It is a VCL error to use resp.do_esi after setting resp.filters.
 
+.. _resp.esi_include_onerror:
 
 resp.esi_include_onerror
 

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -42,6 +42,7 @@ REQ_FLAG(late100cont,		0,    0,    "")
 REQ_FLAG(req_reset,		0,    0,    "")
 REQ_FLAG(res_esi,		0,    0,    "")
 REQ_FLAG(res_pipe,		0,    0,    "")
+REQ_FLAG(esi_include_onerror,	resp, resp, "")
 #define REQ_BEREQ_FLAG(lower, vcl_r, vcl_w, doc) \
 	REQ_FLAG(lower, vcl_r, vcl_w, doc)
 #include "tbl/req_bereq_flags.h"


### PR DESCRIPTION
Backport of vinyl-cache [#4054](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4054) (still tagged WIP upstream, but fully merged to their `main` — verified via its merge commit).

Adds `resp.esi_include_onerror`, settable in `vcl_deliver`, overriding the global `feature esi_include_onerror` parameter on a per-request basis. Includes a small follow-up fixing a forgotten RST anchor in the same doc file.

**First of a 2-PR chain** (tracked in #70): #4518 generalizes this to all ESI flags, hard-ordered after this one.

Builds on #121, which generalizes the `REQ_FLAG`/`BEREQ_FLAG` X-macro system from binary `0`/`1` columns to `0`/`req`/`resp` tokens, so a flag can be scoped to either `req.*` or `resp.*` VCL namespaces — a prerequisite for `resp.esi_include_onerror`.

**Known gap inherited from upstream** (confirmed identical in their own merged commit, not introduced here): `cache_esi_deliver.c` has a second, unrelated-looking usage of `FEATURE(FEATURE_ESI_INCLUDE_ONERROR)` in `ved_deliver()` that isn't wired to the new per-request override — so `resp.esi_include_onerror` only affects one of the two decision points around ESI error handling. May be addressed in #4518.

Part of the backport tracking list in #70.