### PR TITLE
Add storage.Synth as the default for resp.storage

### DIFF
--- a/bin/vinyld/cache/cache_req_fsm.c
+++ b/bin/vinyld/cache/cache_req_fsm.c
@@ -385,7 +385,7 @@ cnt_synth(struct worker *wrk, struct req *req)
 	szl = -1;
 
 	if (req->objcore != NULL ||
-	    Resp_l_storage(req, stv_transient)) {
+	    Resp_l_storage(req, stv_synth)) {
 		CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
 		body = VSB_data(synth_body);
 		szl = VSB_len(synth_body);

--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -460,7 +460,7 @@ VRT_l_resp_storage(VRT_CTX, VCL_STEVEDORE stv)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (stv == NULL)
-		stv = stv_transient;
+		stv = stv_synth;
 	if (! Resp_l_storage(ctx->req, stv))
 		VRT_fail(ctx, "Storage %s failed", stv->vclname);
 }

--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -483,10 +483,6 @@ VRT_l_beresp_storage(VRT_CTX, VCL_STEVEDORE stv)
 	ctx->bo->storage = stv;
 }
 
-/*--------------------------------------------------------------------
- * VCL <= 4.0 ONLY
- */
-
 /*--------------------------------------------------------------------*/
 
 #define VRT_OC_VAR_R(obj, which, which_magic, field)		\

--- a/bin/vinyld/mgt/mgt_main.c
+++ b/bin/vinyld/mgt/mgt_main.c
@@ -941,7 +941,7 @@ main(int argc, char * const *argv)
 	if (!arg_list_count("s"))
 		STV_Config(s_arg);
 
-	/* Configure CLI and Transient storage, if user did not */
+	/* Configure CLI and special storages, if user did not */
 	STV_Config_Final();
 
 	mgt_vcl_init();

--- a/bin/vinyld/mgt/mgt_param_tweak.c
+++ b/bin/vinyld/mgt/mgt_param_tweak.c
@@ -586,10 +586,12 @@ tweak_storage(struct vsb *vsb, const struct parspec *par, const char *arg)
 	if (arg == NULL || arg == JSON_FMT)
 		return (tweak_string(vsb, par, arg));
 
-	if (!strcmp(arg, "Transient")) {
-		/* Always allow setting to the special name
-		 * "Transient". There will always be a stevedore with this
-		 * name, but it may not have been configured at the time
+	if (!strcmp(arg, "Transient") ||
+	    !strcmp(arg, "Synth")) {
+		/* Always allow setting the special names
+		 *
+		 * There will always be a stevedore with each of these names,
+		 * but they may not have been configured at the time
 		 * this is called. */
 	} else {
 		/* Only allow setting the value to a known configured

--- a/bin/vinyld/storage/mgt_stevedore.c
+++ b/bin/vinyld/storage/mgt_stevedore.c
@@ -57,10 +57,12 @@ static struct stevedore_head pre_stevedores =
 static struct stevedore_head stevedores =
     VTAILQ_HEAD_INITIALIZER(stevedores);
 
-/* Name of transient storage */
-#define TRANSIENT_STORAGE	"Transient"
+/* Name of special storages */
+#define TRANSIENT_STORAGE	"Transient"	// passes
+#define SYNTH_STORAGE		"Synth"		// vcl_synth resp.body
 
 struct stevedore *stv_transient;
+struct stevedore *stv_synth;
 
 const char *mgt_stv_h2_rxbuf;
 
@@ -240,14 +242,22 @@ STV_Config(const char *spec)
 void
 STV_Config_Final(void)
 {
+	unsigned have_transient = 0, have_synth = 0;
 	struct stevedore *stv;
 	ASSERT_MGT();
 
 	VCLS_AddFunc(mgt_cls, cli_stv);
-	STV_Foreach(stv)
+	STV_Foreach(stv) {
 		if (!strcmp(stv->ident, TRANSIENT_STORAGE))
-			return;
-	STV_Config(TRANSIENT_STORAGE "=default");
+			have_transient = 1;
+		else if (!strcmp(stv->ident, SYNTH_STORAGE))
+			have_synth = 1;
+	}
+
+	if (! have_transient)
+		STV_Config(TRANSIENT_STORAGE "=default");
+	if (! have_synth)
+		STV_Config(SYNTH_STORAGE "=default");
 }
 
 /*--------------------------------------------------------------------
@@ -302,10 +312,15 @@ STV_Init(void)
 		if (!strcmp(stv->ident, TRANSIENT_STORAGE)) {
 			AZ(stv_transient);
 			stv_transient = stv;
+		} else if (!strcmp(stv->ident, SYNTH_STORAGE)) {
+			AZ(stv_synth);
+			stv_synth = stv;
 		} else
 			VTAILQ_INSERT_TAIL(&stevedores, stv, list);
 		/* NB: Do not free av, stevedore gets to keep it */
 	}
 	AN(stv_transient);
 	VTAILQ_INSERT_TAIL(&stevedores, stv_transient, list);
+	AN(stv_synth);
+	VTAILQ_INSERT_TAIL(&stevedores, stv_synth, list);
 }

--- a/bin/vinyld/storage/storage.h
+++ b/bin/vinyld/storage/storage.h
@@ -143,6 +143,7 @@ struct stevedore {
 };
 
 extern struct stevedore *stv_transient;
+extern struct stevedore *stv_synth;
 extern struct stevedore *stv_h2_rxbuf;
 
 /*--------------------------------------------------------------------*/

--- a/bin/vinyltest/tests/b00017.vtc
+++ b/bin/vinyltest/tests/b00017.vtc
@@ -1,6 +1,6 @@
 vtest "Check set resp.body & storage in vcl_synth"
 
-varnish v1 -arg "-sTransient=debug,lessspace -smalloc=malloc" -vcl {
+varnish v1 -arg "-sSynth=debug,lessspace -smalloc=malloc" -vcl {
 	backend foo {
 		.host = "${bad_backend}";
 	}
@@ -25,7 +25,7 @@ client c1 {
 	expect resp.http.connection != close
 	expect resp.bodylen == 23
 	expect resp.body == "Custom vcl_synth's body"
-	expect resp.http.storage == "storage.Transient"
+	expect resp.http.storage == "storage.Synth"
 
 	txreq -url "/" -hdr "malloc: true"
 	rxresp

--- a/bin/vinyltest/tests/r01284.vtc
+++ b/bin/vinyltest/tests/r01284.vtc
@@ -39,17 +39,19 @@ varnish v1 -expect SM?.Transient.g_bytes > 1048000
 varnish v1 -expect SM?.Transient.g_space < 200
 
 client c1 {
-	# No space for this object (more than 256 bytes in headers). Don't wait
-	# for reply as Varnish will not send one due to Transient full.
+	# No space for this object (more than 256 bytes in headers).
+	# storage.Synth is unaffected
 	txreq -url "/obj2"
-	delay 1
+	rxresp
+	expect resp.status == 503
 } -run
 
 # Three failures, one for obj2, one for vcl_backend_error{}, one for synth objcore
-varnish v1 -expect SM?.Transient.c_fail == 3
+varnish v1 -expect SM?.Transient.c_fail == 2
+varnish v1 -expect SM?.Synth.c_fail == 0
 
 client c1 {
-	# Check that Varnish is still alive
+	# Check that varnishd is still alive
 	txreq -url "/obj1"
 	rxresp
 	expect resp.status == 200

--- a/bin/vinyltest/tests/r03502.vtc
+++ b/bin/vinyltest/tests/r03502.vtc
@@ -52,8 +52,9 @@ client c1 {
 	expect resp.status == 200
 
 	txreq -hdr "Accept-Encoding: gzip"
-	# no storage for synth either
-	expect_close
+	# storage.Synth unaffected
+	rxresp
+	expect resp.status == 503
 } -run
 
 logexpect l1 -wait

--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -403,19 +403,29 @@ like so::
 
   set beresp.storage = storage.myStorage;
 
-A special *name* is ``Transient`` which is the default storage for
-uncacheable objects as resulting from a pass, hit-for-miss or
-hit-for-pass.
-
 If no ``-s`` options are given, the default is::
 
 	-s default,100m
 
-If no ``Transient`` storage is defined, the ``default`` storage is used as if
-defined as::
+Two special *name*\ s are:
+
+* ``Transient``, which is the default storage for uncacheable objects as
+  resulting from a pass, hit-for-miss or hit-for-pass.
+
+  If no ``Transient`` storage is defined, the ``default`` storage is used as if
+  defined as::
 
 	-s Transient=default
 
+* ``Synth``, which is the default storage for synthetic responses created in
+  ``vcl_synth {}``.
+
+  If no ``Synth`` storage is defined, the ``default`` storage is used as if
+  defined as::
+
+	-s Synth=default
+
+.. XXX change to synth ^^^
 
 Storage *kind*\ s (stevedores) can be provided by extensions. The following
 storage *kind*\ s and options are built in:

--- a/doc/sphinx/users-guide/storage-backends.rst
+++ b/doc/sphinx/users-guide/storage-backends.rst
@@ -40,11 +40,14 @@ objects, the rule of thumb is *n* x ``transit_buffer``.
 Storage Selection
 -----------------
 
-By default, Varnish will store short-lived and passed objects in a storage
-called `Transient`, described below.
+For synthetic responses created in ``vcl_synth {}``, storage is selected by
+assigning ``resp.storage``, for which the default is ``Synth`` (see below).
 
-For other objects, it selects from all the non-transient storages in a
-round-robin fashion, unless the VCL variable `beresp.storage` is explicitly set.
+Otherwise, Varnish stores short-lived and passed objects in a storage
+called ``Transient``, also described below.
+
+For all other objects, it selects from all other storages in a round-robin
+fashion, unless the VCL variable ``beresp.storage`` is explicitly set.
 
 -------------------------
 Built in storage backends
@@ -255,18 +258,19 @@ reappear.
 Special Storage names
 ---------------------
 
+Synth
+-----
+
+By default, the storage backend named "Synth" will be used for synthetic objects
+created in ``vcl_synth {}``. By default, Varnish uses an unlimited default
+backend as the ``Synth`` storage.
+
 Transient
 ---------
 
-If you name any of your storage backend "Transient" it will be used
-for transient (short lived) objects. This includes the temporary
-objects created when returning a synthetic object. By default Varnish
-would use an unlimited malloc backend for this.
+If you name any of your storage backends "Transient", it will be used for
+transient (short lived) objects. By default, Varnish uses an unlimited
+default backend as the ``Transient`` storage.
 
-.. XXX: Is this another parameter? In that case handled in the same manner as above? benc
-
-Varnish will consider an object short lived if the TTL is below the
-parameter 'shortlived'.
-
-
-.. XXX: I am generally missing samples of setting all of these parameters, maybe one sample per section or a couple of examples here with a brief explanation to also work as a summary? benc
+Varnish considers an object short lived if the TTL is below the parameter
+'shortlived'.


### PR DESCRIPTION
Backport of [vinyl-cache#4492](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4492), part of the resp.storage chain tracked in #70. Depends on vinyl#4358 (already merged as #98).

Adds a special `Synth` storage (handled the same way as `Transient`) as the default backend for `resp.storage`, used by synthetic responses created in `vcl_synth {}`. Previously synth bodies fell back to the `Transient` storage.

Includes [`6b9cef05a1`](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/6b9cef05a1779ad0b413b02312f4e346b1201c99) as a prerequisite commit — a small comment-gc follow-up to vinyl#4358 that was never its own PR upstream, cherry-picked first so the main commit applies against the same file state as upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)