### PR TITLE
Consistently handle connection ~ close

### DIFF
--- a/bin/vinyld/cache/cache_req_fsm.c
+++ b/bin/vinyld/cache/cache_req_fsm.c
@@ -375,10 +375,11 @@ cnt_synth(struct worker *wrk, struct req *req)
 	http_PrintfHeader(req->resp, "Content-Length: %zd",
 	    VSB_len(synth_body));
 
-	if (req->doclose == SC_NULL &&
-	    (http_HdrIs(req->resp, H_Connection, "close") ||
-	    http_HdrIs(req->http, H_Connection, "close")))
-		req->doclose = SC_RESP_CLOSE;
+	// also happens in cnt_transmit, but we need req->doclose earlier for VRB_Ignore
+	if (req->doclose == SC_NULL)
+		req->doclose = http_DoConnection(req->http, SC_REQ_CLOSE);
+	if (req->doclose == SC_NULL)
+		req->doclose = http_DoConnection(req->resp, SC_RESP_CLOSE);
 
 	/* Discard any lingering request body before delivery */
 	(void)VRB_Ignore(req);
@@ -446,6 +447,11 @@ cnt_transmit(struct worker *wrk, struct req *req)
 	AZ(req->res_pipe | req->res_esi);
 	AZ(req->boc);
 	req->req_step = R_STP_FINISH;
+
+	if (req->doclose == SC_NULL)
+		req->doclose = http_DoConnection(req->http, SC_REQ_CLOSE);
+	if (req->doclose == SC_NULL)
+		req->doclose = http_DoConnection(req->resp, SC_RESP_CLOSE);
 
 	/* Grab a ref to the bo if there is one (=streaming) */
 	req->boc = HSH_RefBoc(req->objcore);

--- a/bin/vinyltest/tests/c00064.vtc
+++ b/bin/vinyltest/tests/c00064.vtc
@@ -1,35 +1,111 @@
-vtest "Connection: close in vcl_synth{}"
+vtest "Connection: close all the cases"
 
 server s1 {
 	rxreq
-	txresp -status 400
+	txresp -status 200
 } -start
 
 varnish v1 -vcl+backend {
-	sub vcl_miss {
-		if (req.url == "/333") {
-			return (synth(333, "FOO"));
-		} else {
-			return (synth(334, "BAR"));
+	sub vcl_recv {
+		if (req.http.req) {
+			set req.http.Connection = req.http.req;
+		}
+		if (req.url == "/synth") {
+			return (synth(200));
 		}
 	}
 
-	sub vcl_synth {
-		if (resp.status == 333) {
-			set resp.http.connection = "close";
+	sub do_resp {
+		if (req.http.resp) {
+			set resp.http.Connection = req.http.resp;
 		}
+	}
+
+	sub vcl_deliver {
+		call do_resp;
+	}
+
+	sub vcl_synth {
+		call do_resp;
 	}
 } -start
 
 client c1 {
-	txreq -url /334
+	txreq
 	rxresp
-	expect resp.status == 334
-	txreq -url /334
+	expect resp.http.Connection == keep-alive
+
+	txreq -url /synth
 	rxresp
-	expect resp.status == 334
-	txreq -url /333
+	expect resp.http.Connection == keep-alive
+} -start
+
+# Simple cases were the header is just "close"
+client c2 {
+	txreq -hdr "req: close"
 	rxresp
-	expect resp.status == 333
+	expect resp.http.Connection == close
 	expect_close
-} -run
+} -start
+
+client c3 {
+	txreq -url /synth -hdr "req: close"
+	rxresp
+	expect resp.http.Connection == close
+	expect_close
+} -start
+
+client c4 {
+	txreq -hdr "resp: close"
+	rxresp
+	expect resp.http.Connection == close
+	expect_close
+} -start
+
+client c5 {
+	txreq -url /synth -hdr "resp: close"
+	rxresp
+	expect resp.http.Connection == close
+	expect_close
+} -start
+
+# Additional header name in Connection:
+client c12 {
+	txreq -hdr "req: foo, close"
+	rxresp
+	expect resp.http.Connection == close
+	expect_close
+} -start
+
+client c13 {
+	txreq -url /synth -hdr "req: foo, close"
+	rxresp
+	expect resp.http.Connection == close
+	expect_close
+} -start
+
+client c14 {
+	txreq -hdr "resp: foo, close"
+	rxresp
+	expect resp.http.Connection == close
+	expect_close
+} -start
+
+client c15 {
+	txreq -url /synth -hdr "resp: foo, close"
+	rxresp
+	expect resp.http.Connection == close
+	expect_close
+} -start
+
+client c1 -wait
+
+client c2 -wait
+client c3 -wait
+client c4 -wait
+client c5 -wait
+
+client c12 -wait
+client c13 -wait
+client c14 -wait
+client c15 -wait


### PR DESCRIPTION
7c1806b98e98e59b936dcc0fecf845ab6d5aa114 correctly added handling for vcl-controlled connection close by setting `req.http.connection`, but only for the synth case and not a normal deliver.

Also, `http_HdrIs(req->resp, H_Connection, "close")` was already wrong before, because the connection: header legitimately can contain other tokens.

Upstream: https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4495