### PR TITLE
Stash objcore references until the end of the task to avoid copies

### DIFF
--- a/bin/vinyld/cache/cache.h
+++ b/bin/vinyld/cache/cache.h
@@ -564,6 +564,8 @@ struct req {
 	struct vrt_privs	privs[1];
 
 	struct vcf		*vcf;
+
+	struct ocstash		*stash;
 };
 
 #define IS_TOPREQ(req) ((req)->top->topreq == (req))

--- a/bin/vinyld/cache/cache_req.c
+++ b/bin/vinyld/cache/cache_req.c
@@ -49,6 +49,53 @@
 #include "tls/cache_tls.h"
 #include "vtim.h"
 
+/*--------------------------------------------------------------------
+ * Facility to keep obcore references until the end of the task across restarts
+ */
+
+struct ocstash {
+	unsigned		magic;
+#define OCSTASH_MAGIC		0x242031b5
+	uint16_t		l;
+	uint16_t		n;
+	struct objcore *	ocs[] v_counted_by_(l);
+};
+
+static void
+ocstash_push(struct ocstash *stash, struct objcore **ocp)
+{
+
+	CHECK_OBJ_NOTNULL(stash, OCSTASH_MAGIC);
+	assert(stash->n < stash->l);
+	TAKE_OBJ_NOTNULL(stash->ocs[stash->n], ocp, OBJCORE_MAGIC);
+	stash->n++;
+}
+
+static void
+ocstash_clear(struct worker *wrk, struct ocstash *stash)
+{
+	uint16_t u;
+
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	CHECK_OBJ_NOTNULL(stash, OCSTASH_MAGIC);
+	assert(stash->n <= stash->l);
+	for (u = 0; u < stash->n; u++)
+		(void)HSH_DerefObjCore(wrk, &stash->ocs[u]);
+	for (; u < stash->l; u++)
+		AZ(stash->ocs[u]);
+	stash->n = 0;
+}
+
+void
+Req_StashObjcore(struct req *req, struct objcore **ocp)
+{
+
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	ocstash_push(req->stash, ocp);
+}
+
+/*--------------------------------------------------------------------*/
+
 void
 Req_AcctLogCharge(struct VSC_main_wrk *ds, struct req *req)
 {
@@ -132,7 +179,7 @@ Req_New(struct sess *sp, const struct req *preq)
 {
 	struct pool *pp;
 	struct req *req;
-	uint16_t nhttp;
+	uint16_t l, nhttp;
 	unsigned sz, hl;
 	char *p, *e;
 
@@ -205,6 +252,17 @@ Req_New(struct sess *sp, const struct req *preq)
 		p = (void*)PRNDUP(p + sizeof(*req->top));
 	}
 
+	req->max_restarts = cache_param->max_restarts;
+	assert(req->max_restarts + 1 <= UINT16_MAX);
+	// each restart may ref one stale_oc and one oc
+	l = (2 * req->max_restarts) + 1;
+	sz = SIZEOF_FLEX_OBJ(req->stash, ocs, l);
+	req->stash = (void*)p;
+	req->stash->magic = OCSTASH_MAGIC;
+	req->stash->l = l;
+	p += sz;
+	p = (void*)PRNDUP(p);
+
 	assert(p < e);
 
 	WS_Init(req->ws, "req", p, e - p);
@@ -214,7 +272,6 @@ Req_New(struct sess *sp, const struct req *preq)
 	req->t_req = NAN;
 	req->req_step = R_STP_TRANSPORT;
 	req->doclose = SC_NULL;
-	req->max_restarts = cache_param->max_restarts;
 
 	return (req);
 }
@@ -267,6 +324,7 @@ Req_Rollback(VRT_CTX)
 	if (IS_TOPREQ(req))
 		VCL_TaskLeave(ctx, req->top->privs);
 	VCL_TaskLeave(ctx, req->privs);
+	ocstash_clear(req->wrk, req->stash);
 	VCL_TaskEnter(req->privs);
 	if (IS_TOPREQ(req))
 		VCL_TaskEnter(req->top->privs);
@@ -297,6 +355,8 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 
 	AZ(req->director_hint);
 	req->restarts = 0;
+
+	ocstash_clear(wrk, req->stash);
 
 	if (req->vcl != NULL)
 		VCL_Recache(wrk, &req->vcl);

--- a/bin/vinyld/cache/cache_req_fsm.c
+++ b/bin/vinyld/cache/cache_req_fsm.c
@@ -240,7 +240,7 @@ cnt_deliver(struct worker *wrk, struct req *req)
 
 	if (wrk->vpi->handling != VCL_RET_DELIVER) {
 		HSH_Cancel(wrk, req->objcore, NULL);
-		(void)HSH_DerefObjCore(wrk, &req->objcore);
+		Req_StashObjcore(req, &req->objcore);
 		http_Teardown(req->resp);
 
 		switch (wrk->vpi->handling) {
@@ -691,8 +691,7 @@ cnt_lookup(struct worker *wrk, struct req *req)
 		WRONG("Illegal return from vcl_hit{}");
 	}
 
-	/* Drop our object, we won't need it */
-	(void)HSH_DerefObjCore(wrk, &req->objcore);
+	Req_StashObjcore(req, &req->objcore);
 
 	if (busy != NULL) {
 		HSH_Withdraw(wrk, &busy);
@@ -722,7 +721,7 @@ cnt_miss(struct worker *wrk, struct req *req)
 		wrk->stats->cache_miss++;
 		VBF_Fetch(wrk, req, req->objcore, req->stale_oc, VBF_NORMAL);
 		if (req->stale_oc != NULL)
-			(void)HSH_DerefObjCore(wrk, &req->stale_oc);
+			Req_StashObjcore(req, &req->stale_oc);
 		req->req_step = R_STP_FETCH;
 		return (REQ_FSM_MORE);
 	case VCL_RET_FAIL:
@@ -742,7 +741,7 @@ cnt_miss(struct worker *wrk, struct req *req)
 	}
 	VRY_Clear(req);
 	if (req->stale_oc != NULL)
-		(void)HSH_DerefObjCore(wrk, &req->stale_oc);
+		Req_StashObjcore(req, &req->stale_oc);
 	HSH_Withdraw(wrk, &req->objcore);
 	return (REQ_FSM_MORE);
 }

--- a/bin/vinyld/cache/cache_vinyld.h
+++ b/bin/vinyld/cache/cache_vinyld.h
@@ -432,6 +432,7 @@ void Req_Fail(struct req *req, stream_close_t reason);
 void Req_AcctLogCharge(struct VSC_main_wrk *, struct req *);
 void Req_LogHit(struct worker *, struct req *, struct objcore *, intmax_t);
 const char *Req_LogStart(const struct worker *, struct req *);
+void Req_StashObjcore(struct req *, struct objcore **);
 int Resp_l_storage(struct req *req, const struct stevedore *stv);
 
 /* cache_req_body.c */

--- a/bin/vinyld/cache/cache_vrt.c
+++ b/bin/vinyld/cache/cache_vrt.c
@@ -95,14 +95,6 @@ VRT_synth(VRT_CTX, VCL_INT code, VCL_STRING reason)
 		return;
 	}
 
-	if (reason && !WS_Allocated(ctx->ws, reason, -1)) {
-		reason = WS_Copy(ctx->ws, reason, -1);
-		if (!reason) {
-			VRT_fail(ctx, "Workspace overflow");
-			return;
-		}
-	}
-
 	if (ctx->req == NULL) {
 		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
 		ctx->bo->err_code = (uint16_t)code;
@@ -459,12 +451,11 @@ VRT_StrandsWS(struct ws *ws, const char *h, VCL_STRANDS s)
 		}
 	}
 
-	if (q == NULL) {
-		if (h == NULL)
-			return ("");
-		if (WS_Allocated(ws, h, -1))
-			return (h);
-	} else if (h == NULL && WS_Allocated(ws, q, -1)) {
+	if (q == NULL && h == NULL)
+		return ("");
+	if (q == NULL)
+		return (h);
+	if (h == NULL) {
 		for (i++; i < s->n; i++)
 			if (s->p[i] != NULL && *s->p[i] != '\0')
 				break;

--- a/bin/vinyltest/tests/b00092.vtc
+++ b/bin/vinyltest/tests/b00092.vtc
@@ -2,11 +2,16 @@ vtest "Use multiple objects for a single request"
 
 server s0 {
 	rxreq
-	txresp -hdr "method: O1_METHOD"
+	expect req.url == /
+	txresp -hdr "url: /2" -hdr "method: O1_METHOD" -hdr "bodypart: head,"
+
 	rxreq
-	txresp -hdr "url: /o2_url"
+	expect req.url == /2
+	txresp -hdr "url: /o2_url" -hdr "bodypart: arms,"
+
 	rxreq
-	txresp -hdr "val: 3"
+	expect req.url == /o2_url
+	txresp -hdr "val: 3" -body "all the rest"
 } -start
 
 
@@ -19,23 +24,35 @@ varnish v1 -vcl+backend {
 	import debug;
 
 	sub vcl_recv {
+		if (req.http.cache) {
+			return (hash);
+		}
 		return (pass);
 	}
 	sub vcl_deliver {
 		if (req.restarts == 0) {
 			set req.method = resp.http.method;
+			set req.url = resp.http.url;
 			debug.log_strands("resp.http.method", resp.http.method);
+			debug.body_prefix(resp.http.bodypart);
 		} else if (req.restarts == 1) {
 			set req.url = resp.http.url;
 			debug.log_strands("resp.http.url", resp.http.url);
+			debug.body_prefix(resp.http.bodypart);
 		} else {
 			set resp.http.method = req.method;
 			set resp.http.url = req.url;
 			debug.log_strands("req.method", req.method);
 			debug.log_strands("req.url", req.url);
+			set resp.filters = "debug.body_prefix";
 			return (deliver);
 		}
 		return (restart);
+	}
+
+	sub vcl_backend_response {
+		set beresp.ttl = 1s;
+		set beresp.grace = 0s;
 	}
 } -start
 
@@ -45,4 +62,24 @@ client c1 {
 	expect resp.http.method == O1_METHOD
 	expect resp.http.url == /o2_url
 	expect resp.http.val == 3
+	expect resp.body == "head,arms,all the rest"
 } -run
+server s0 -wait
+
+# check that we do not leak references: as soon as the request is done with, all
+# three objects need to be deleted (because pass)
+varnish v1 -expect n_object == 0
+
+## re-run with cached objects, just to be sure
+
+server s0 -start
+client c1 {
+	txreq -hdr "cache: 1"
+	rxresp
+	expect resp.http.method == O1_METHOD
+	expect resp.http.url == /o2_url
+	expect resp.http.val == 3
+	expect resp.body == "head,arms,all the rest"
+} -run
+varnish v1 -expect n_object == 0
+server s0 -wait

--- a/bin/vinyltest/tests/r02219.vtc
+++ b/bin/vinyltest/tests/r02219.vtc
@@ -11,6 +11,7 @@ server s1 {
 
 varnish v1 -arg "-p workspace_client=9k" \
 	   -arg "-p vsl_buffer=4k" \
+	   -arg "-p max_restarts=2" \
 	   -proto PROXY \
 	   -vcl+backend {
 	import std;
@@ -22,7 +23,7 @@ varnish v1 -arg "-p workspace_client=9k" \
 } -start
 
 client c1 {
-	send "PROXY TCP4 127.0.0.1 127.0.0.1 1111 2222\r\nGET /${string,repeat,736,A} HTTP/1.1\r\n\r\n"
+	send "PROXY TCP4 127.0.0.1 127.0.0.1 1111 2222\r\nGET /${string,repeat,720,A} HTTP/1.1\r\n\r\n"
 	rxresp
 } -run
 
@@ -32,13 +33,13 @@ client c2 {
 0d 0a 0d 0a 00 0d 0a 51 55 49 54 0a
 21 00 00 00
 47 45 54 20 2f
-${string,repeat,732,"42 "}
+${string,repeat,716,"42 "}
 20 48 54 54 50 2f 31 2e 31 0d 0a 0d 0a
 }
 	rxresp
 } -run
 
 client c3 {
-	send "PROXY TCP4 127.0.0.1 127.0.0.1 1111 2222\r\nGET /${string,repeat,740,C} HTTP/1.1\r\n\r\n"
+	send "PROXY TCP4 127.0.0.1 127.0.0.1 1111 2222\r\nGET /${string,repeat,724,C} HTTP/1.1\r\n\r\n"
 	rxresp
 } -run

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -787,7 +787,7 @@ PARAM_SIMPLE(
 	/* name */	max_restarts,
 	/* type */	uint,
 	/* min */	"0",
-	/* max */	"65534",	// (1<<16)-2 #4269
+	/* max */	"32766",	// (1<<15)-2 #4269
 	/* def */	"4",
 	/* units */	"restarts",
 	/* descr */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -787,7 +787,7 @@ PARAM_SIMPLE(
 	/* name */	max_restarts,
 	/* type */	uint,
 	/* min */	"0",
-	/* max */	NULL,
+	/* max */	"65534",	// (1<<16)-2 #4269
 	/* def */	"4",
 	/* units */	"restarts",
 	/* descr */
@@ -799,7 +799,7 @@ PARAM_SIMPLE(
 	/* name */	max_retries,
 	/* type */	uint,
 	/* min */	"0",
-	/* max */	NULL,
+	/* max */	"65534",	// (1<<16)-2 #4269
 	/* def */	"4",
 	/* units */	"retries",
 	/* descr */

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1390,3 +1390,32 @@ xyzzy_log_strands(VRT_CTX, VCL_STRING prefix, VCL_STRANDS subject, VCL_INT nn)
 		    ptr_where(ctx, p), p, n, p, strlen(p) > (unsigned)n ? "..." : "");
 	}
 }
+
+const void * const priv_task_id_bp = &priv_task_id_bp;
+
+VCL_VOID
+xyzzy_body_prefix(VRT_CTX, VCL_STRING s)
+{
+	struct xyzzy_bp_string *bps;
+	struct xyzzy_bp *bp;
+	struct vmod_priv *task;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	task = VRT_priv_task(ctx, priv_task_id_bp);
+	AN(task);
+	bp = task->priv;
+	if (bp == NULL) {
+		bp = WS_Alloc(ctx->ws, (unsigned)sizeof *bp);
+		AN(bp);
+		task->priv = bp;
+		INIT_OBJ(bp, XYZZY_BP_MAGIC);
+		VSTAILQ_INIT(&bp->head);
+	}
+	CHECK_OBJ(bp, XYZZY_BP_MAGIC);
+
+	bps = WS_Alloc(ctx->ws, (unsigned)sizeof *bps);
+	AN(bps);
+	bps->s = s;
+	VSTAILQ_INSERT_TAIL(&bp->head, bps, list);
+}

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -669,8 +669,6 @@ xyzzy_concatenate(VRT_CTX, VCL_STRANDS s)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	r = VRT_StrandsWS(ctx->ws, NULL, s);
-	if (r != NULL && *r != '\0')
-		AN(WS_Allocated(ctx->ws, r, strlen(r) + 1));
 	return (r);
 }
 
@@ -681,8 +679,6 @@ xyzzy_collect(VRT_CTX, VCL_STRANDS s)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	r = VRT_STRANDS_string(ctx, s);
-	if (r != NULL && *r != '\0')
-		AN(WS_Allocated(ctx->ws, r, strlen(r) + 1));
 	return (r);
 }
 
@@ -715,8 +711,6 @@ xyzzy_sethdr(VRT_CTX, VCL_HEADER hdr, VCL_STRANDS s)
 			VSLbs(ctx->vsl, SLT_LostHeader,
 			    TOSTRAND(hdr->what->str));
 		} else {
-			if (*b != '\0')
-				AN(WS_Allocated(hp->ws, b, strlen(b) + 1));
 			http_Unset(hp, hdr->what);
 			http_SetHeader(hp, b);
 		}

--- a/vmod/vmod_debug.h
+++ b/vmod/vmod_debug.h
@@ -34,6 +34,20 @@ debug_add_filters(VRT_CTX);
 void
 debug_remove_filters(VRT_CTX);
 
+/* body_prefix vdp */
+struct xyzzy_bp_string {
+	VSTAILQ_ENTRY(xyzzy_bp_string)	list;
+	VCL_STRING			s;
+};
+
+struct xyzzy_bp {
+	unsigned			magic;
+#define XYZZY_BP_MAGIC			0x88db5d93
+	VSTAILQ_HEAD(,xyzzy_bp_string)	head;
+};
+
+extern const void * const priv_task_id_bp;
+
 /* vmod_debug_transport_reembarking_http1.c */
 void
 debug_transport_reembarking_http1_use(VRT_CTX);

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -515,6 +515,10 @@ $Function VOID body_string(STRING)
 
 Set the string to send as the body with the ``debug.string`` filter.
 
+$Function VOID body_prefix(STRING)
+
+Add this string to the prefix sent by the body_prefix filter
+
 DEPRECATED
 ==========
 

--- a/vmod/vmod_debug_filters.c
+++ b/vmod/vmod_debug_filters.c
@@ -864,6 +864,74 @@ xyzzy_body_string(VRT_CTX, VCL_STRING s)
 	p->priv = TRUST_ME(s);
 }
 
+/**********************************************************************/
+
+static int v_matchproto_(vdp_init_f)
+xyzzy_vdp_body_prefix_init(VRT_CTX, struct vdp_ctx *vdc, void **priv)
+{
+	struct xyzzy_bp_string *bps;
+	struct xyzzy_bp *bp;
+	struct vmod_priv *task;
+	intmax_t l;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(vdc, VDP_CTX_MAGIC);
+	AN(vdc->clen);
+
+	task = VRT_priv_task_get(ctx, priv_task_id_bp);
+	if (task == NULL)
+		return (1);
+	CAST_OBJ_NOTNULL(bp, task->priv, XYZZY_BP_MAGIC);
+	AN(priv);
+	AZ(*priv);
+	*priv = bp;
+
+	if (*vdc->clen < 0)
+		return (0);
+
+	l = 0;
+	VSTAILQ_FOREACH(bps, &bp->head, list)
+		l += strlen(bps->s);
+	*vdc->clen += l;
+
+	return (0);
+}
+
+static int v_matchproto_(vdp_bytes_f)
+xyzzy_vdp_body_prefix_bytes(struct vdp_ctx *vdc, enum vdp_action act, void **priv,
+    const void *ptr, ssize_t len)
+{
+	struct xyzzy_bp_string *bps;
+	struct xyzzy_bp *bp;
+
+	AN(priv);
+	CAST_OBJ_NOTNULL(bp, *priv, XYZZY_BP_MAGIC);
+
+	while ((bps = VSTAILQ_FIRST(&bp->head)) != NULL) {
+		VSTAILQ_REMOVE_HEAD(&bp->head, list);
+		if (VDP_bytes(vdc, VDP_NULL, bps->s, strlen(bps->s)))
+			return (vdc->retval);
+	}
+
+	return (VDP_bytes(vdc, act, ptr, len));
+}
+
+static int v_matchproto_(vdp_fini_f)
+xyzzy_vdp_body_prefix_fini(struct vdp_ctx *vdc, void **priv)
+{
+	(void)vdc;
+	AN(priv);
+	*priv = NULL;
+	return (0);
+}
+
+static const struct vdp xyzzy_vdp_body_prefix = {
+	.name  = "debug.body_prefix",
+	.init  = xyzzy_vdp_body_prefix_init,
+	.bytes = xyzzy_vdp_body_prefix_bytes,
+	.fini = xyzzy_vdp_body_prefix_fini
+};
+
 void
 debug_add_filters(VRT_CTX)
 {
@@ -876,6 +944,7 @@ debug_add_filters(VRT_CTX)
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_chklen));
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_awshog));
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_string));
+	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_body_prefix));
 }
 
 void
@@ -890,4 +959,5 @@ debug_remove_filters(VRT_CTX)
 	VRT_RemoveFilter(ctx, NULL, &xyzzy_vdp_chklen);
 	VRT_RemoveFilter(ctx, NULL, &xyzzy_vdp_awshog);
 	VRT_RemoveFilter(ctx, NULL, &xyzzy_vdp_string);
+	VRT_RemoveFilter(ctx, NULL, &xyzzy_vdp_body_prefix);
 }


### PR DESCRIPTION
Backport of [vinyl-cache#4269](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4269), part of the resp.storage chain tracked in #70.

4 commits, in landing order:
1. `params: give a sensible upper limit to max_restarts and max_retries`
2. `req: New facility to retain objcores`
3. `cache_vrt: Avoid making unnecessary copies of strings`
4. `req: test our new ocstash's capability`

The new `struct ocstash` allocation in commit 2 shrinks `workspace_client`'s usable space, so `r02219.vtc`'s tight-workspace overflow calibration needed a small reduction to keep passing with the extra allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)