### PR TITLE
Add VCL per-beresp control over all ESI flags

### DIFF
--- a/bin/vinyld/cache/cache_esi_fetch.c
+++ b/bin/vinyld/cache/cache_esi_fetch.c
@@ -61,6 +61,17 @@ struct vef_priv {
 	ssize_t			ibuf_sz;
 };
 
+static struct vep_flags
+vep_flags(const struct busyobj *bo) {
+	struct vep_flags flags = {0};
+
+	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
+#define BERESP_ESI_FLAG(lower, feature, doc) \
+	flags.lower = bo->lower;
+#include "tbl/beresp_esi_flags.h"
+	return (flags);
+}
+
 static ssize_t
 vfp_vep_callback(struct vfp_ctx *vc, void *priv, ssize_t l, enum vgz_flag flg)
 {
@@ -174,7 +185,8 @@ vfp_esi_gzip_init(VRT_CTX, struct vfp_ctx *vc, struct vfp_entry *vfe)
 	if (vef == NULL)
 		return (VFP_ERROR);
 	vc->obj_flags |= OF_GZIPED | OF_CHGCE | OF_ESIPROC;
-	vef->vep = VEP_Init(vc, vc->req, vfp_vep_callback, vef);
+	vef->vep = VEP_Init(vc, vc->req, vfp_vep_callback, vef,
+	    vep_flags(ctx->bo));
 	if (vef->vep == NULL) {
 		FREE_OBJ(vef);
 		return (VFP_ERROR);
@@ -257,7 +269,7 @@ vfp_esi_init(VRT_CTX, struct vfp_ctx *vc, struct vfp_entry *vfe)
 		    "Attempted ESI on partial (206) response");
 		return (VFP_ERROR);
 	}
-	vep = VEP_Init(vc, vc->req, NULL, NULL);
+	vep = VEP_Init(vc, vc->req, NULL, NULL, vep_flags(ctx->bo));
 	if (vep == NULL)
 		return (VFP_ERROR);
 	ALLOC_OBJ(vef, VEF_MAGIC);

--- a/bin/vinyld/cache/cache_esi_parse.c
+++ b/bin/vinyld/cache/cache_esi_parse.c
@@ -651,7 +651,7 @@ VEP_Parse(struct vep_state *vep, const char *p, size_t l)
 		 */
 
 		if (vep->state == VEP_START) {
-			if (FEATURE(FEATURE_ESI_REMOVE_BOM) &&
+			if (vep->flags.esi_remove_bom &&
 			    *p == (char)0xeb) {
 				vep->match = vep_match_bom;
 				vep->state = VEP_MATCH;

--- a/bin/vinyld/cache/cache_esi_parse.c
+++ b/bin/vinyld/cache/cache_esi_parse.c
@@ -59,6 +59,9 @@ enum vep_mark { VERBATIM = 0, SKIP };
 struct vep_state {
 	unsigned		magic;
 #define VEP_MAGIC		0x55cb9b82
+	// flags from bereq
+	struct vep_flags	flags;
+
 	struct vsb		*vsb;
 
 	const char		*url;
@@ -531,7 +534,7 @@ vep_do_include(struct vep_state *vep, enum dowhat what)
 		VSB_printf(vep->vsb, "%c", incl);
 		VSB_printf(vep->vsb, "Host: %.*s%c", (int)(p-h), h, 0);
 	} else if (l > 8 && !memcmp(p, "https://", 8)) {
-		if (!FEATURE(FEATURE_ESI_IGNORE_HTTPS)) {
+		if (!vep->flags.esi_ignore_https) {
 			vep_warn(vep,
 			    "ESI 1.0 <esi:include> with https:// ignored");
 			vep->state = VEP_TAGERROR;
@@ -1065,7 +1068,7 @@ vep_default_cb(struct vfp_ctx *vc, void *priv, ssize_t l, enum vgz_flag flg)
 
 struct vep_state *
 VEP_Init(struct vfp_ctx *vc, const struct http *req, vep_callback_t *cb,
-    void *cb_priv)
+    void *cb_priv, struct vep_flags flags)
 {
 	struct vep_state *vep;
 
@@ -1079,6 +1082,7 @@ VEP_Init(struct vfp_ctx *vc, const struct http *req, vep_callback_t *cb,
 	}
 
 	INIT_OBJ(vep, VEP_MAGIC);
+	vep->flags = flags;
 	vep->url = req->hd[HTTP_HDR_URL].b;
 	vep->vc = vc;
 	vep->vsb = VSB_new_auto();

--- a/bin/vinyld/cache/cache_esi_parse.c
+++ b/bin/vinyld/cache/cache_esi_parse.c
@@ -702,7 +702,7 @@ VEP_Parse(struct vep_state *vep, const char *p, size_t l)
 		 */
 
 		} else if (vep->state == VEP_NOTMYTAG) {
-			if (FEATURE(FEATURE_ESI_IGNORE_OTHER_ELEMENTS)) {
+			if (vep->flags.esi_ignore_other_elements) {
 				p++;
 				vep->state = VEP_NEXTTAG;
 			} else {

--- a/bin/vinyld/cache/cache_esi_parse.c
+++ b/bin/vinyld/cache/cache_esi_parse.c
@@ -659,7 +659,7 @@ VEP_Parse(struct vep_state *vep, const char *p, size_t l)
 				vep->state = VEP_BOM;
 		} else if (vep->state == VEP_BOM) {
 			vep_mark_skip(vep, p);
-			if (FEATURE(FEATURE_ESI_DISABLE_XML_CHECK))
+			if (vep->flags.esi_disable_xml_check)
 				vep->state = VEP_NEXTTAG;
 			else
 				vep->state = VEP_TESTXML;

--- a/bin/vinyld/cache/cache_fetch.c
+++ b/bin/vinyld/cache/cache_fetch.c
@@ -66,6 +66,14 @@ FETCH_STEPS
 
 static hdr_t const H_X_Varnish = HDR("X-Varnish");
 
+static void
+init_esi_flags(struct busyobj *bo) {
+	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
+#define BERESP_ESI_FLAG(lower, feature, doc) \
+	bo->lower = FEATURE(feature);
+#include "tbl/beresp_esi_flags.h"
+}
+
 /*--------------------------------------------------------------------
  * Allocate an object, with fall-back to Transient.
  * XXX: This somewhat overlaps the stuff in stevedore.c
@@ -338,6 +346,7 @@ vbf_stp_retry(struct worker *wrk, struct busyobj *bo)
 	bo->between_bytes_timeout = NAN;
 	if (bo->htc != NULL)
 		bo->htc->doclose = SC_NULL;
+	init_esi_flags(bo);
 
 	// XXX: BereqEnd + BereqAcct ?
 	VSL_ChgId(bo->vsl, "bereq", "retry", VXID_Get(wrk, VSL_BACKENDMARKER));
@@ -1198,6 +1207,8 @@ VBF_Fetch(struct worker *wrk, struct req *req, struct objcore *oc,
 	bo = VBO_GetBusyObj(wrk, req);
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 	AN(bo->vcl);
+
+	init_esi_flags(bo);
 
 	boc = HSH_RefBoc(oc);
 	CHECK_OBJ_NOTNULL(boc, BOC_MAGIC);

--- a/bin/vinyld/fuzzers/esi_parse_fuzzer.c
+++ b/bin/vinyld/fuzzers/esi_parse_fuzzer.c
@@ -145,7 +145,7 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 	if (data[0] & 0x8f)
 		flags.esi_ignore_https = 1;
 	if (size > 1 && data[1] & 0x8f)
-		BSET(__cache_param.feature_bits, FEATURE_ESI_DISABLE_XML_CHECK);
+		flags.esi_disable_xml_check = 1;
 	if (size > 2 && data[2] & 0x8f)
 		BSET(__cache_param.feature_bits, FEATURE_ESI_IGNORE_OTHER_ELEMENTS);
 	if (size > 3 && data[3] & 0x8f)

--- a/bin/vinyld/fuzzers/esi_parse_fuzzer.c
+++ b/bin/vinyld/fuzzers/esi_parse_fuzzer.c
@@ -129,6 +129,7 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 	struct vep_state *vep;
 	struct vsb *vsb;
 	txt hd[HTTP_HDR_URL + 1];
+	struct vep_flags flags = {0};
 	char ws_buf[1024];
 
 	if (size < 1)
@@ -142,7 +143,7 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 	memset(&__cache_param, 0, sizeof(__cache_param));
 #define BSET(b, no) (b)[(no) >> 3] |= (0x80 >> ((no) & 7))
 	if (data[0] & 0x8f)
-		BSET(__cache_param.feature_bits, FEATURE_ESI_IGNORE_HTTPS);
+		flags.esi_ignore_https = 1;
 	if (size > 1 && data[1] & 0x8f)
 		BSET(__cache_param.feature_bits, FEATURE_ESI_DISABLE_XML_CHECK);
 	if (size > 2 && data[2] & 0x8f)
@@ -172,7 +173,8 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 	vc->wrk = wrk;
 	vc->resp = resp;
 
-	vep = VEP_Init(vc, req, NULL, NULL);
+	vep = VEP_Init(vc, req, NULL, NULL, flags);
+
 	AN(vep);
 	VEP_Parse(vep, (const char *)data, size);
 	vsb = VEP_Finish(vep);

--- a/bin/vinyld/fuzzers/esi_parse_fuzzer.c
+++ b/bin/vinyld/fuzzers/esi_parse_fuzzer.c
@@ -141,7 +141,6 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 	cache_param = &__cache_param;
 
 	memset(&__cache_param, 0, sizeof(__cache_param));
-#define BSET(b, no) (b)[(no) >> 3] |= (0x80 >> ((no) & 7))
 	if (data[0] & 0x8f)
 		flags.esi_ignore_https = 1;
 	if (size > 1 && data[1] & 0x8f)
@@ -149,8 +148,7 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 	if (size > 2 && data[2] & 0x8f)
 		flags.esi_ignore_other_elements = 1;
 	if (size > 3 && data[3] & 0x8f)
-		BSET(__cache_param.feature_bits, FEATURE_ESI_REMOVE_BOM);
-#undef BSET
+		flags.esi_remove_bom = 1;
 
 	/* Setup ws */
 	WS_Init(ws, "req", ws_buf, sizeof ws_buf);

--- a/bin/vinyld/fuzzers/esi_parse_fuzzer.c
+++ b/bin/vinyld/fuzzers/esi_parse_fuzzer.c
@@ -147,7 +147,7 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 	if (size > 1 && data[1] & 0x8f)
 		flags.esi_disable_xml_check = 1;
 	if (size > 2 && data[2] & 0x8f)
-		BSET(__cache_param.feature_bits, FEATURE_ESI_IGNORE_OTHER_ELEMENTS);
+		flags.esi_ignore_other_elements = 1;
 	if (size > 3 && data[3] & 0x8f)
 		BSET(__cache_param.feature_bits, FEATURE_ESI_REMOVE_BOM);
 #undef BSET

--- a/bin/vinyltest/tests/e00006.vtc
+++ b/bin/vinyltest/tests/e00006.vtc
@@ -60,6 +60,7 @@ varnish v1 -vcl+backend {
 	sub vcl_recv {
 		set req.backend_hint = s2;
 		set req.backend_hint = s1;
+		return (pass);
 	}
 	sub vcl_backend_response {
 		set beresp.do_esi = true;
@@ -84,7 +85,7 @@ client c1 {
 varnish v1 -expect esi_errors == 1
 varnish v1 -expect MAIN.s_resp_bodybytes == 82
 
-client c1 {
+client c2 {
 	txreq -url /https
 	rxresp
 	expect resp.status == 200
@@ -95,3 +96,24 @@ logexpect l1 -wait
 
 varnish v1 -expect esi_errors == 2
 varnish v1 -expect MAIN.s_resp_bodybytes == 88
+
+varnish v1 -cliok "param.set feature -esi_ignore_https"
+
+server s1 -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		set req.backend_hint = s2;
+		set req.backend_hint = s1;
+		return (pass);
+	}
+	sub vcl_backend_response {
+		set beresp.do_esi = true;
+		set beresp.esi_ignore_https = true;
+	}
+}
+
+logexpect l1 -start
+client c1 -run
+client c2 -run
+logexpect l1 -wait

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1171,6 +1171,21 @@ beresp.do_stream
 	This variable has no effect if beresp.do_esi is true or when
 	the response body is empty.
 
+.. _beresp.esi_disable_xml_check:
+
+beresp.esi_disable_xml_check
+
+	Type: BOOL
+
+	Readable from: vcl_backend_response
+
+	Writable from: vcl_backend_response
+
+	Default: feature esi_disable_xml_check
+
+	Allow ESI processing on non-XML ESI bodies
+
+
 .. _beresp.esi_ignore_https:
 
 beresp.esi_ignore_https

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1171,6 +1171,19 @@ beresp.do_stream
 	This variable has no effect if beresp.do_esi is true or when
 	the response body is empty.
 
+.. _beresp.esi_ignore_https:
+
+beresp.esi_ignore_https
+
+	Type: BOOL
+
+	Readable from: vcl_backend_response
+
+	Writable from: vcl_backend_response
+
+	Default: feature esi_ignore_https
+
+	Whether to convert ``<esi:include src\"https://...`` to ``http://...``
 
 .. _beresp.filters:
 

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1200,6 +1200,18 @@ beresp.esi_ignore_https
 
 	Whether to convert ``<esi:include src\"https://...`` to ``http://...``
 
+beresp.esi_ignore_other_elements
+
+	Type: BOOL
+
+	Readable from: vcl_backend_response
+
+	Writable from: vcl_backend_response
+
+	Default: feature esi_ignore_other_elements
+
+        Ignore XML syntax errors in ESI bodies.
+
 .. _beresp.filters:
 
 beresp.filters

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1210,7 +1210,19 @@ beresp.esi_ignore_other_elements
 
 	Default: feature esi_ignore_other_elements
 
-        Ignore XML syntax errors in ESI bodies.
+	Ignore XML syntax errors in ESI bodies.
+
+beresp.esi_remove_bom
+
+	Type: BOOL
+
+	Readable from: vcl_backend_response
+
+	Writable from: vcl_backend_response
+
+	Default: feature esi_remove_bom
+
+	Ignore UTF-8 BOM in ESI bodies.
 
 .. _beresp.filters:
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -10,6 +10,7 @@ nobase_pkginclude_HEADERS = \
 	tbl/ban_vars.h \
 	tbl/bereq_flags.h \
 	tbl/beresp_flags.h \
+	tbl/beresp_esi_flags.h \
 	tbl/boc_state.h \
 	tbl/body_status.h \
 	tbl/cli_cmds.h \

--- a/include/tbl/beresp_esi_flags.h
+++ b/include/tbl/beresp_esi_flags.h
@@ -1,8 +1,8 @@
 /*-
- * Copyright (c) 2011 Varnish Software AS
+ * Copyright 2026 UPLEX - Nils Goroll Systemoptimierung
  * All rights reserved.
  *
- * Author: Poul-Henning Kamp <phk@phk.freebsd.dk>
+ * Author: Nils Goroll <nils.goroll@uplex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -29,30 +29,13 @@
  *
  */
 
-#define	VEC_GZ	(0x21)
-#define	VEC_V1	(0x40 + 1)
-#define	VEC_V2	(0x40 + 2)
-#define	VEC_V8	(0x40 + 8)
-#define	VEC_C1	(0x50 + 1)
-#define	VEC_C2	(0x50 + 2)
-#define	VEC_C8	(0x50 + 8)
-#define	VEC_S1	(0x60 + 1)
-#define	VEC_S2	(0x60 + 2)
-#define	VEC_S8	(0x60 + 8)
-#define	VEC_IA	(0x40 + 9)
-#define	VEC_IC	(0x60 + 9)
+/*lint -save -e525 -e539 */
 
-typedef ssize_t vep_callback_t(struct vfp_ctx *, void *priv, ssize_t l,
-    enum vgz_flag flg);
+/*
+ * esi flags: defaults inherited from feature flag
+ *
+ * lower, feature, doc */
+BERESP_ESI_FLAG(esi_ignore_https, FEATURE_ESI_IGNORE_HTTPS, "")
+#undef BERESP_ESI_FLAG
 
-// flags inherited from bo BEREQ_FLAGS
-struct vep_flags {
-#define BERESP_ESI_FLAG(lower, feature, doc) \
-	unsigned lower:1;
-#include "tbl/beresp_esi_flags.h"
-};
-
-struct vep_state *VEP_Init(struct vfp_ctx *vc, const struct http *req,
-    vep_callback_t *cb, void *cb_priv, struct vep_flags flags);
-void VEP_Parse(struct vep_state *, const char *p, size_t l);
-struct vsb *VEP_Finish(struct vep_state *);
+/*lint -restore */

--- a/include/tbl/beresp_esi_flags.h
+++ b/include/tbl/beresp_esi_flags.h
@@ -35,6 +35,7 @@
  * esi flags: defaults inherited from feature flag
  *
  * lower, feature, doc */
+BERESP_ESI_FLAG(esi_disable_xml_check, FEATURE_ESI_DISABLE_XML_CHECK, "")
 BERESP_ESI_FLAG(esi_ignore_https, FEATURE_ESI_IGNORE_HTTPS, "")
 #undef BERESP_ESI_FLAG
 

--- a/include/tbl/beresp_esi_flags.h
+++ b/include/tbl/beresp_esi_flags.h
@@ -37,6 +37,7 @@
  * lower, feature, doc */
 BERESP_ESI_FLAG(esi_disable_xml_check, FEATURE_ESI_DISABLE_XML_CHECK, "")
 BERESP_ESI_FLAG(esi_ignore_https, FEATURE_ESI_IGNORE_HTTPS, "")
+BERESP_ESI_FLAG(esi_ignore_other_elements, FEATURE_ESI_IGNORE_OTHER_ELEMENTS, "")
 #undef BERESP_ESI_FLAG
 
 /*lint -restore */

--- a/include/tbl/beresp_esi_flags.h
+++ b/include/tbl/beresp_esi_flags.h
@@ -38,6 +38,7 @@
 BERESP_ESI_FLAG(esi_disable_xml_check, FEATURE_ESI_DISABLE_XML_CHECK, "")
 BERESP_ESI_FLAG(esi_ignore_https, FEATURE_ESI_IGNORE_HTTPS, "")
 BERESP_ESI_FLAG(esi_ignore_other_elements, FEATURE_ESI_IGNORE_OTHER_ELEMENTS, "")
+BERESP_ESI_FLAG(esi_remove_bom, FEATURE_ESI_REMOVE_BOM, "")
 #undef BERESP_ESI_FLAG
 
 /*lint -restore */

--- a/include/tbl/beresp_flags.h
+++ b/include/tbl/beresp_flags.h
@@ -36,10 +36,13 @@
  *
  * lower, vcl_r, vcl_w, filters, doc */
 BERESP_FLAG(do_esi,		1, 1, 1, "")
-BERESP_FLAG(do_gzip,	1, 1, 1, "")
-BERESP_FLAG(do_gunzip,	1, 1, 1, "")
-BERESP_FLAG(do_stream,	1, 1, 0, "")
-BERESP_FLAG(was_304,	1, 0, 0, "")
+BERESP_FLAG(do_gzip,		1, 1, 1, "")
+BERESP_FLAG(do_gunzip,		1, 1, 1, "")
+BERESP_FLAG(do_stream,		1, 1, 0, "")
+BERESP_FLAG(was_304,		1, 0, 0, "")
+#define BERESP_ESI_FLAG(lower, feature, doc) \
+BERESP_FLAG(lower,		1, 1, 0, doc)
+#include "tbl/beresp_esi_flags.h"
 #undef BERESP_FLAG
 
 /*lint -restore */


### PR DESCRIPTION
Backport of [vinyl-cache#4518](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4518), tracked in #70. Generalizes vinyl#4054 (#100) to all ESI feature flags.

4 commits, in landing order, each adding one `beresp.esi_*` VCL variable defaulting to its corresponding `feature` param, mirroring the pattern #100 established for `esi_include_onerror`:
1. `beresp.esi_ignore_https`
2. `beresp.esi_disable_xml_check`
3. `beresp.esi_ignore_other_elements`
4. `beresp.esi_remove_bom`

🤖 Generated with [Claude Code](https://claude.com/claude-code)