### PR TITLE
Misc flexelint/stabilization fixes (cache_vpi, d00035.vtc, cache_vinyld.h)

### DIFF
--- a/bin/vinyld/cache/cache_vinyld.h
+++ b/bin/vinyld/cache/cache_vinyld.h
@@ -161,9 +161,6 @@ struct vcf {
 
 /* Prototypes etc ----------------------------------------------------*/
 
-/* cache_backend.c */
-struct backend;
-
 /* cache_backend_cfg.c */
 void VBE_InitCfg(void);
 

--- a/bin/vinyld/cache/cache_vpi.c
+++ b/bin/vinyld/cache/cache_vpi.c
@@ -132,7 +132,7 @@ vpi_ref_panic(struct vsb *vsb, unsigned n, const struct vcl *vcl)
 	VSB_printf(vsb, "line = %u,\n", ref->line);
 	VSB_printf(vsb, "pos = %u,\n", ref->pos);
 	if (src != NULL) {
-		VSB_cat(vsb, "src = "); 
+		VSB_cat(vsb, "src = ");
 		VSB_quote(vsb, src, 40, VSB_QUOTE_CSTR | VSB_QUOTE_ABBREVIATE);
 		VSB_putc(vsb, '\n');
 	} else {

--- a/bin/vinyltest/tests/d00035.vtc
+++ b/bin/vinyltest/tests/d00035.vtc
@@ -57,3 +57,5 @@ client c2 {
 } -run
 
 client c1 -wait
+server s1 -wait
+server s2 -wait


### PR DESCRIPTION
## Summary
- ws cleanup in cache_vpi.c (trailing whitespace)
- stabilize d00035.vtc (wait for both servers before test end)
- gc superfluous `struct backend;` declaration in cache_vinyld.h (flexelint)

Backport of three unrelated small vinyl-cache fixes (part of the vinyl-tail commit-porting work tracked in #70). All exact ports, authorship preserved.

## Test plan
- [ ] CI