### PR TITLE
doc: storage backend documentation improvements

### DIFF
--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -411,8 +411,8 @@ If no ``-s`` options are given, the default is::
 
 	-s default,100m
 
-If no ``Transient`` storage is defined, the default is an unbound
-``default`` storage as if defined as::
+If no ``Transient`` storage is defined, the ``default`` storage is used as if
+defined as::
 
 	-s Transient=default
 

--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -276,13 +276,14 @@ Tuning options
   `List of Parameters`_ for details. This option can be used multiple
   times to specify multiple parameters.
 
--s <[name=]type[,options]>
+-s <[name=]kind[,options]>
 
-  Use the specified storage backend. See `Storage Backend`_ section.
+  Use the specified storage backend. See `ref-varnishd-opt_s` and the `Storage
+  Backend`_ section.
 
-  This option can be used multiple times to specify multiple storage
-  files. Name is referenced in logs, VCL, statistics, etc. If name
-  is not specified, "s0", "s1" and so forth is used.
+  This option can be used multiple times to define multiple storage backends.
+  *name* is referenced in logs, VCL, statistics, etc. If *name* is not
+  specified, "s0", "s1" and so forth are used.
 
 -l <vsl>
 
@@ -396,9 +397,9 @@ The argument format to define storage backends is:
 
   For *kind* and *options* see details below.
 
-Storages can be used in vcl as ``storage.``\ *name*, so, for
-example if ``myStorage`` was defined by ``-s myStorage=malloc,5G``, it
-could be used in VCL like so::
+Storages are available in vcl as ``storage.``\ *name*, so, for example if
+``myStorage`` was defined by ``-s myStorage=malloc,5G``, it could be used in VCL
+like so::
 
   set beresp.storage = storage.myStorage;
 
@@ -416,11 +417,12 @@ If no ``Transient`` storage is defined, the default is an unbound
 	-s Transient=default
 
 
-The following storage types and options are available:
+Storage *kind*\ s (stevedores) can be provided by extensions. The following
+storage *kind*\ s and options are built in:
 
 -s <default[,size]>
 
-  The default storage type resolves to ``umem`` where available and
+  The default storage kind resolves to ``umem`` where available and
   ``malloc`` otherwise.
 
 -s <malloc[,size]>

--- a/doc/sphinx/users-guide/storage-backends.rst
+++ b/doc/sphinx/users-guide/storage-backends.rst
@@ -28,6 +28,7 @@ Storage backends are also called stevedores.
 .. _vmods: https://www.varnish-cache.org/vmods
 
 Besides the built-in storage backends, separately distributed extensions exist,
+which can be found on the `vmods`_ page by searching for "stevedore".
 
 Storage Selection
 ~~~~~~~~~~~~~~~~~

--- a/doc/sphinx/users-guide/storage-backends.rst
+++ b/doc/sphinx/users-guide/storage-backends.rst
@@ -5,12 +5,14 @@
 
 .. _guide-storage:
 
+================
 Storage backends
-----------------
+================
 
 
+-----
 Intro
-~~~~~
+-----
 
 Varnish has pluggable storage backends. It can store data in various
 backends which can have different performance characteristics. The default
@@ -31,7 +33,7 @@ Besides the built-in storage backends, separately distributed extensions exist,
 which can be found on the `vmods`_ page by searching for "stevedore".
 
 Storage Selection
-~~~~~~~~~~~~~~~~~
+-----------------
 
 By default, Varnish will store short-lived and passed objects in a storage
 called `Transient`, described below.
@@ -39,8 +41,12 @@ called `Transient`, described below.
 For other objects, it will rotate between all the non-transient storages,
 unless the VCL variable `beresp.storage` is explicitly set.
 
+-------------------------
+Built in storage backends
+-------------------------
+
 default
-~~~~~~~
+-------
 
 syntax: default[,size]
 
@@ -48,7 +54,7 @@ The default storage backend is an alias to umem, where available, or
 malloc otherwise.
 
 malloc
-~~~~~~
+------
 
 syntax: malloc[,size]
 
@@ -89,7 +95,7 @@ depend on the operating system's ability to page effectively.
 .. _guide-storage_umem:
 
 umem
-~~~~
+----
 
 syntax: umem[,size]
 
@@ -137,7 +143,7 @@ be reconfigured once loaded.
 .. _libumem: http://dtrace.org/blogs/ahl/2004/07/13/number-11-of-20-libumem/
 
 file
-~~~~
+----
 
 syntax: file,path[,size[,granularity[,advice]]]
 
@@ -205,7 +211,7 @@ On Linux, large objects and rotational disk should benefit from
 "sequential".
 
 deprecated_persistent
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 syntax: deprecated_persistent,path,size {experimental}
 
@@ -240,8 +246,12 @@ the silo was offline will not be applied to the silo when it reenters
 the cache. Consequently enabling previously banned objects to
 reappear.
 
-Transient Storage
------------------
+---------------------
+Special Storage names
+---------------------
+
+Transient
+---------
 
 If you name any of your storage backend "Transient" it will be used
 for transient (short lived) objects. This includes the temporary

--- a/doc/sphinx/users-guide/storage-backends.rst
+++ b/doc/sphinx/users-guide/storage-backends.rst
@@ -20,17 +20,22 @@ configuration is to use the malloc backend with a limited size. For a
 serious Varnish deployment you probably would want to adjust the storage
 settings.
 
-All built-in storage backends cache full objects only, so, for example, to
-support *n* concurrent cache hits on 1GB sized objects, the storage backend
-should be configured to provide at least *n*\ GB of storage. For uncacheable
-objects, the rule of thumb is *n* x ``transit_buffer``.
+While some storage backends can be created dynamically, for most applications a
+global definition is advised using the ``-s`` parameter to :ref:`varnishd(1)`, as
+documented in detail under :ref:`ref-varnishd-opt_s`::
 
-Storage backends are also called stevedores.
+    [-s [name=]kind[,options]]
 
 .. _vmods: https://www.varnish-cache.org/vmods
 
-Besides the built-in storage backends, separately distributed extensions exist,
+*kind* refers to the storage implementation, also called stevedore. Some storage
+implementations are built in and additional ones are provided by extensions,
 which can be found on the `vmods`_ page by searching for "stevedore".
+
+All built-in storage implementations cache full objects only, so, for example,
+to support *n* concurrent cache hits on 1GB sized objects, the storage backend
+should be configured to provide at least *n*\ GB of storage. For uncacheable
+objects, the rule of thumb is *n* x ``transit_buffer``.
 
 Storage Selection
 -----------------
@@ -38,8 +43,8 @@ Storage Selection
 By default, Varnish will store short-lived and passed objects in a storage
 called `Transient`, described below.
 
-For other objects, it will rotate between all the non-transient storages,
-unless the VCL variable `beresp.storage` is explicitly set.
+For other objects, it selects from all the non-transient storages in a
+round-robin fashion, unless the VCL variable `beresp.storage` is explicitly set.
 
 -------------------------
 Built in storage backends
@@ -58,7 +63,7 @@ malloc
 
 syntax: malloc[,size]
 
-Malloc is a virtual memory based storage backend. Each object will be allocated
+Malloc is a virtual memory based storage backend, which allocates each object
 using whatever ``malloc()`` implementation is in effect. If configured, virtual
 memory might get paged in and out to swap space by the operating system.
 
@@ -88,9 +93,9 @@ fragmentation, the amount of memory actually used by the malloc implementation
 might be substantially higher by a factor of typically **two to four times**.
 Specific optimizations like :ref:`platform-thp` can amplify this effect.
 
-malloc's performance is bound to memory speed, so it is very fast. If
-the dataset is bigger than available memory, performance will
-depend on the operating system's ability to page effectively.
+malloc's performance is bound to memory speed, so it is very fast. If the
+dataset is bigger than available memory, performance depends on the operating
+system's ability to page effectively.
 
 .. _guide-storage_umem:
 
@@ -175,12 +180,12 @@ suffixes:
 
       T, t    The size is expressed in tebibytes.
 
-If 'path' points to an existing file and no size is specified, the
-size of the existing file will be used. If 'path' does not point to an
-existing file it is an error to not specify the size.
+If 'path' points to an existing file and no size is specified, the size of the
+existing file is used. If 'path' does not point to an existing file it is an
+error to not specify the size.
 
-If the backing file already exists, it will be truncated or expanded
-to the specified size.
+If the backing file already exists, it is truncated or expanded to the specified
+size.
 
 Note that if `varnishd` has to create or expand the file, it will not
 pre-allocate the added space, leading to fragmentation, which may


### PR DESCRIPTION
## Summary
- doc: bring back a lost line (storage-backends.rst)
- doc: Fix storage user guide document structure (heading restructure)
- doc: Improve storage related documentation (storage-backends.rst + varnishd.rst)
- doc: polish Transient doc (varnishd.rst)

Backport of four vinyl-cache doc commits (part of the vinyl-tail commit-porting work tracked in #70). Two are exact ports; two are adjusted since upstream's `vinyld.rst` maps to this repo's `varnishd.rst` (fixed the `ref-vinyld-opt_s`/`vinyld(1)` refs accordingly and dropped a duplicate `vmods` link target the merge introduced).

## Test plan
- [x] Both touched .rst files parse clean with docutils
- [ ] CI