### PR TITLE
Shut down pools when stopping

### DIFF
--- a/bin/vinyld/cache/cache_main.c
+++ b/bin/vinyld/cache/cache_main.c
@@ -563,6 +563,7 @@ child_main(int sigmagic, size_t altstksz)
 		VTIM_sleep(shutdown_delay);
 
 	VCA_Shutdown();
+	cache_param->wthread_pools = 0;
 	BAN_Shutdown();
 	STV_warn();
 	VCL_Shutdown();

--- a/bin/vinyld/cache/cache_pool.c
+++ b/bin/vinyld/cache/cache_pool.c
@@ -208,8 +208,7 @@ pool_poolherder(void *priv)
 				nwq++;
 				continue;
 			}
-		} else if (nwq > cache_param->wthread_pools &&
-				EXPERIMENT(EXPERIMENT_DROP_POOLS)) {
+		} else if (nwq > cache_param->wthread_pools) {
 			Lck_Lock(&pool_mtx);
 			pp = VTAILQ_FIRST(&pools);
 			CHECK_OBJ_NOTNULL(pp, POOL_MAGIC);
@@ -219,7 +218,7 @@ pool_poolherder(void *priv)
 				nwq--;
 			Lck_Unlock(&pool_mtx);
 			if (!pp->die) {
-				VSL(SLT_Debug, NO_VXID, "XXX Kill Pool %p", pp);
+				VSL(SLT_Debug, NO_VXID, "Kill Pool %p", pp);
 				pp->die = 1;
 				VCA_DestroyPool(pp);
 				PTOK(pthread_cond_signal(&pp->herder_cond));

--- a/bin/vinyltest/tests/c00080.vtc
+++ b/bin/vinyltest/tests/c00080.vtc
@@ -9,7 +9,6 @@ server s1 {
 
 varnish v1 -vcl+backend {} -start
 
-varnish v1 -cliok "param.set experimental +drop_pools"
 varnish v1 -cliok "param.set debug +slow_acceptor"
 varnish v1 -cliok "param.set thread_pools 1"
 
@@ -40,7 +39,6 @@ server s1 {
 
 varnish v2 -arg "-Wpoll" -vcl+backend {} -start
 
-varnish v2 -cliok "param.set experimental +drop_pools"
 varnish v2 -cliok "param.set debug +slow_acceptor"
 varnish v2 -cliok "param.set thread_pools 1"
 

--- a/include/tbl/experimental_bits.h
+++ b/include/tbl/experimental_bits.h
@@ -33,7 +33,7 @@
 
 /*lint -save -e525 -e539 */
 
-EXPERIMENTAL_BIT(DROP_POOLS,	drop_pools,	"Drop thread pools")
+// currently no experimental bits
 #undef EXPERIMENTAL_BIT
 
 /*lint -restore */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1594,12 +1594,8 @@ PARAM_THREAD(
 	"worker pools may be required.\n"
 	"\n"
 	"Too many pools waste CPU and RAM resources, and more than one "
-	"pool for each CPU is most likely detrimental to performance.\n"
-	"\n"
-	"Can be increased on the fly, but decreases require a "
-	"restart to take effect, unless the drop_pools experimental "
-	"debug flag is set.",
-	/* flags */	EXPERIMENTAL | DELAYED_EFFECT
+	"pool for each CPU is most likely detrimental to performance.",
+	/* flags */	DELAYED_EFFECT
 )
 
 PARAM_THREAD(


### PR DESCRIPTION
## Summary
- Removes the `EXPERIMENTAL` gate on worker-pool count decreases (`drop_pools` debug flag)
- Sets `wthread_pools = 0` on shutdown so pools actually drain when varnishd stops, instead of relying on an opt-in experimental flag

Backport of a vinyl-cache commit (part of the vinyl-tail commit-porting work tracked in #70). Only adjustment: resolved a `varnish`/`vinyl` vtc DSL-keyword conflict in `c00080.vtc` (dropped the now-removed `param.set experimental +drop_pools` line, kept `varnish` naming).

## Test plan
- [ ] CI