### PR TITLE
Remove VCL synthetic() action and VRT_synth_*()/VRT_Stv()

### DIFF
--- a/bin/vinyld/cache/cache_req_fsm.c
+++ b/bin/vinyld/cache/cache_req_fsm.c
@@ -371,10 +371,6 @@ cnt_synth(struct worker *wrk, struct req *req)
 	}
 	assert(wrk->vpi->handling == VCL_RET_DELIVER);
 
-	http_Unset(req->resp, H_Content_Length);
-	http_PrintfHeader(req->resp, "Content-Length: %zd",
-	    VSB_len(synth_body));
-
 	// also happens in cnt_transmit, but we need req->doclose earlier for VRB_Ignore
 	if (req->doclose == SC_NULL)
 		req->doclose = http_DoConnection(req->http, SC_REQ_CLOSE);

--- a/bin/vinyld/cache/cache_vrt.c
+++ b/bin/vinyld/cache/cache_vrt.c
@@ -891,28 +891,30 @@ VRT_Rollback(VRT_CTX, VCL_HTTP hp)
 VCL_VOID
 VRT_synth_strands(VRT_CTX, VCL_STRANDS s)
 {
-	struct vsb *vsb;
-	int i;
+	int i, hasnull = 0;
+	const char * const s_null = "(null)";
 
-	CAST_OBJ_NOTNULL(vsb, ctx->specific, VSB_MAGIC);
 	CHECK_OBJ_NOTNULL(s, STRANDS_MAGIC);
 	for (i = 0; i < s->n; i++) {
 		if (s->p[i] != NULL)
-			VSB_cat(vsb, s->p[i]);
-		else
-			VSB_cat(vsb, "(null)");
+			continue;
+		s->p[i] = s_null;
+		hasnull = 1;
+	}
+
+	VRT_l_resp_body(ctx, LBODY_ADD_STRING, NULL, s);
+	if (hasnull == 0)
+		return;
+	for (i = 0; i < s->n; i++) {
+		if (s->p[i] == s_null)
+			s->p[i] = NULL;
 	}
 }
 
 VCL_VOID
 VRT_synth_blob(VRT_CTX, VCL_BLOB b)
 {
-	struct vsb *vsb;
-	CAST_OBJ_NOTNULL(vsb, ctx->specific, VSB_MAGIC);
-
-	CHECK_OBJ_NOTNULL(b, VRT_BLOB_MAGIC);
-	if (b->len > 0 && b->blob != NULL)
-		VSB_bcat(vsb, b->blob, b->len);
+	VRT_l_resp_body(ctx, LBODY_SET_BLOB, NULL, b);
 }
 
 VCL_VOID

--- a/bin/vinyld/cache/cache_vrt.c
+++ b/bin/vinyld/cache/cache_vrt.c
@@ -888,43 +888,6 @@ VRT_Rollback(VRT_CTX, VCL_HTTP hp)
 
 /*--------------------------------------------------------------------*/
 
-VCL_VOID
-VRT_synth_strands(VRT_CTX, VCL_STRANDS s)
-{
-	int i, hasnull = 0;
-	const char * const s_null = "(null)";
-
-	CHECK_OBJ_NOTNULL(s, STRANDS_MAGIC);
-	for (i = 0; i < s->n; i++) {
-		if (s->p[i] != NULL)
-			continue;
-		s->p[i] = s_null;
-		hasnull = 1;
-	}
-
-	VRT_l_resp_body(ctx, LBODY_ADD_STRING, NULL, s);
-	if (hasnull == 0)
-		return;
-	for (i = 0; i < s->n; i++) {
-		if (s->p[i] == s_null)
-			s->p[i] = NULL;
-	}
-}
-
-VCL_VOID
-VRT_synth_blob(VRT_CTX, VCL_BLOB b)
-{
-	VRT_l_resp_body(ctx, LBODY_SET_BLOB, NULL, b);
-}
-
-VCL_VOID
-VRT_synth_page(VRT_CTX, VCL_STRANDS s)
-{
-	VRT_synth_strands(ctx, s);
-}
-
-/*--------------------------------------------------------------------*/
-
 static VCL_STRING
 vrt_ban_error(VRT_CTX, VCL_STRING err)
 {

--- a/bin/vinyld/storage/stevedore.c
+++ b/bin/vinyld/storage/stevedore.c
@@ -283,15 +283,6 @@ stv_find(const char *nm)
 	return (NULL);
 }
 
-int
-VRT_Stv(const char *nm)
-{
-
-	if (stv_find(nm) != NULL)
-		return (1);
-	return (0);
-}
-
 const char * v_matchproto_()
 VRT_STEVEDORE_string(VCL_STEVEDORE s)
 {

--- a/bin/vinyltest/tests/m00053.vtc
+++ b/bin/vinyltest/tests/m00053.vtc
@@ -84,7 +84,7 @@ varnish v1 -vcl {
 			}
 			debug.call(foo);
 		} else if (req.url == "/checkwrong") {
-			synthetic(debug.check_call(bar));
+			set resp.body = debug.check_call(bar);
 			set resp.status = 500;
 		}
 		return (deliver);

--- a/bin/vinyltest/tests/r01287.vtc
+++ b/bin/vinyltest/tests/r01287.vtc
@@ -1,4 +1,4 @@
-vtest "#1287 - check NULL as first pointer to VRT_synth_page"
+vtest "#1287 - check NULL as input to resp.body"
 
 server s1 {
 } -start
@@ -8,7 +8,7 @@ varnish v1 -vcl+backend {
 		return (synth(200, "OK"));
 	}
 	sub vcl_synth {
-		synthetic(resp.http.blank);
+		set resp.body = resp.http.blank;
 		return (deliver);
 	}
 } -start
@@ -17,5 +17,5 @@ client c1 {
 	txreq
 	rxresp
 	expect resp.status == 200
-	expect resp.body == "(null)"
+	expect resp.body == ""
 } -run

--- a/bin/vinyltest/tests/r03079.vtc
+++ b/bin/vinyltest/tests/r03079.vtc
@@ -36,9 +36,9 @@ varnish v1 -vcl {
 	}
 	sub vcl_synth {
 		if (req.url ~ "synth") {
-			synthetic("hello");
+			set resp.body = "hello";
 			if (req.url ~ "add") {
-				synthetic("world");
+				set resp.body += "world";
 			}
 		}
 		if (req.url ~ "string") {

--- a/bin/vinyltest/tests/v00018.vtc
+++ b/bin/vinyltest/tests/v00018.vtc
@@ -93,9 +93,9 @@ varnish v1 -errvcl "Symbol not found" {
 	sub vcl_recv { kluf ; }
 }
 
-varnish v1 -errvcl {Unknown token '<<' when looking for STRING} {
+varnish v1 -errvcl {Unknown token '<<' when looking for BODY} {
 	backend b { .host = "${localhost}"; }
-	sub vcl_synth { synthetic( << "foo"; }
+	sub vcl_synth { set resp.body = << "foo"; }
 }
 
 varnish v1 -errvcl {Missing argument.} {
@@ -117,7 +117,7 @@ varnish v1 -errvcl {Expected return action name.} {
 varnish v1 -errvcl {Not a valid action in subroutine 'vcl_recv'} {
 	backend foo { .host = "${localhost}"; }
 	sub vcl_recv {
-		synthetic("XXX");
+		hash_data("XXX");
 		return (synth(503));
 	}
 }

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -64,6 +64,9 @@ Varnish-Cache NEXT (unreleased)
   internally, while ``set resp.body = <nullstring>`` creates the empty string
   ``""`` and ``set resp.body += <nullstring>`` is a NOOP.
 
+* The functions ``VRT_synth_strands()``, ``VRT_synth_blob()``,
+  ``VRT_synth_page()`` and ``VRT_Stv()`` have been removed from the runtime.
+
 * ``varnish{log,ncsa,hist,top}`` all gained the ``-0`` dry-run argument that
   allows testing a command line before running it for real.
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -43,6 +43,27 @@ Varnish-Cache NEXT (unreleased)
 
 .. _VSV00019: https://vinyl-cache.org/security/VSV00019.html
 
+* The ``synthetic()`` VCL action has been removed. Since Varnish Cache 5.0.0,
+  body data can be created by setting ``beresp.body`` in ``vcl_backend_error
+  {}`` and by setting ``resp.body`` in ``vcl_synth {}``, and these continue to
+  be available as the one way to create body data, as in these examples:
+
+  - ``set resp.body = "string" + " more strings";``
+  - ``set resp.body += " appending even " + "more strings";``
+  - ``set resp.body = :blob:;``
+  - ``set resp.body += :blobappend:;``
+
+  These examples equally work on ``beresp.body`` in ``vcl_backend_error {}``.
+
+  The direct replacement for ``synthetic(<string>);`` is ``set resp.body +=
+  <string>;`` in ``vcl_synth {}`` and ``set beresp.body += <string>;`` in
+  ``vcl_backend_error {}``.
+
+  The only difference in behavior is that ``synthetic(<nullstring>)`` would
+  create the string ``(null)`` for ``<nullstring>`` being a ``NULL`` pointer
+  internally, while ``set resp.body = <nullstring>`` creates the empty string
+  ``""`` and ``set resp.body += <nullstring>`` is a NOOP.
+
 * ``varnish{log,ncsa,hist,top}`` all gained the ``-0`` dry-run argument that
   allows testing a command line before running it for real.
 

--- a/doc/sphinx/reference/vcl.rst
+++ b/doc/sphinx/reference/vcl.rst
@@ -452,14 +452,6 @@ hash_data(input)
   Adds an input to the hash input. In the built-in VCL ``hash_data()``
   is called on the host and URL of the request. Available in ``vcl_hash``.
 
-synthetic(STRING)
-~~~~~~~~~~~~~~~~~
-
-  Prepare a synthetic response body containing the *STRING*. Available
-  in ``vcl_synth`` and ``vcl_backend_error``.
-
-  Identical to ``set resp.body`` /  ``set beresp.body``.
-
 .. list above comes from struct action_table[] in vcc_action.c.
 
 regsub(str, regex, sub)

--- a/doc/sphinx/reference/vcl_step.rst
+++ b/doc/sphinx/reference/vcl_step.rst
@@ -251,9 +251,16 @@ of the following keywords:
 vcl_synth
 ~~~~~~~~~
 
-Called to deliver a synthetic object. A synthetic object is generated
-in VCL, not fetched from the backend. Its body may be constructed using
-the ``synthetic()`` function.
+Called to deliver a synthetic object. A synthetic object is generated in VCL,
+not fetched from the backend. Its body can be constructed by assigning a string
+or blob to ``resp.body`` using ``=``, or by appending a string or blob to
+``resp.body`` using ``+=``, as in these examples::
+
+  - ``set resp.body = "string";``
+  - ``set resp.body = "string " + "and another";``
+  - ``set resp.body += " appending " + "more strings";``
+  - ``set resp.body = :blob:;``
+  - ``set resp.body += :blobappend==:;``
 
 A `vcl_synth` defined object never enters the cache, contrary to a
 :ref:`vcl_backend_error` defined object, which may end up in cache.
@@ -420,19 +427,26 @@ The `vcl_backend_response` subroutine may terminate with calling
 vcl_backend_error
 ~~~~~~~~~~~~~~~~~
 
-This subroutine is called if we fail the backend fetch or if
-*max_retries* has been exceeded.
+This subroutine is called if we fail the backend fetch, if *max_retries* has
+been exceeded, or if explicitly transitioned to with ``return(error(status code,
+reason))``.
 
 Returning with :ref:`abandon` does not leave a cache object.
 
-If returning with ``deliver`` and ``beresp.uncacheable == false``, a
-synthetic cache object is generated in VCL, whose body may be constructed
-using the ``synthetic()`` function.
+If returning with ``deliver``, a synthetic body can be constructed by assigning
+a string or blob to ``beresp.body`` using ``=``, or by appending a string or
+blob to ``beresp.body`` using ``+=``, as in these examples::
 
-Since these synthetic objects are cached in these special circumstances,
-be cautious with putting private information there. If you really must,
-then you need to explicitly set ``beresp.uncacheable`` to ``true`` in
-``vcl_backend_error``.
+  - ``set beresp.body = "string";``
+  - ``set beresp.body = "string " + "and another";``
+  - ``set beresp.body += " appending " + "more strings";``
+  - ``set beresp.body = :blob:;``
+  - ``set beresp.body += :blobappend==:;``
+
+For ``return(deliver)`` with ``beresp.uncacheable == false``, the constructed
+object is cached, so be cautious with putting private information in headers or
+the body of such a cached object. When in doubt, explicitly set
+``beresp.uncacheable`` to ``true`` in ``vcl_backend_error`` to avoid caching.
 
 The `vcl_backend_error` subroutine may terminate with calling ``return()``
 with one of the following keywords:

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -59,6 +59,10 @@
  *
  * 22.2 (trunk)
  *	struct vrt_endpoint.ssl_ca_file added
+ *	VRT_synth_strands() removed
+ *	VRT_synth_blob() removed
+ *	VRT_synth_page() removed
+ *	VRT_Stv() removed
  * 22.1
  *	"vcl_name" member added to vrt_backend_probe{}
  *	VRT_PROBE_string() added
@@ -832,10 +836,6 @@ VCL_VOID VRT_hashdata(VRT_CTX, VCL_STRANDS);
 
 VCL_VOID VRT_Rollback(VRT_CTX, VCL_HTTP);
 
-/* Synthetic pages */
-VCL_VOID VRT_synth_strands(VRT_CTX, VCL_STRANDS);
-VCL_VOID VRT_synth_blob(VRT_CTX, VCL_BLOB);
-
 /***********************************************************************
  * VDI - Director API
  */
@@ -941,10 +941,3 @@ void VRT_VCL_Allow_Cold(struct vclref **);
 
 struct vclref * VRT_VCL_Prevent_Discard(VRT_CTX, const char *);
 void VRT_VCL_Allow_Discard(struct vclref **);
-
-/***********************************************************************
- * Deprecated interfaces, do not use, they will disappear at some point.
- */
-
-VCL_VOID VRT_synth_page(VRT_CTX, VCL_STRANDS);
-int VRT_Stv(const char *nm);

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -412,27 +412,6 @@ vcc_act_return(struct vcc *tl, struct token *t, struct symbol *sym)
 
 /*--------------------------------------------------------------------*/
 
-static void v_matchproto_(sym_act_f)
-vcc_act_synthetic(struct vcc *tl, struct token *t, struct symbol *sym)
-{
-
-	(void)t;
-	(void)sym;
-	ExpectErr(tl, '(');
-	ERRCHK(tl);
-	vcc_NextToken(tl);
-
-	Fb(tl, 1, "VRT_synth_strands(ctx, ");
-	vcc_Expr(tl, STRANDS);
-	ERRCHK(tl);
-	Fb(tl, 1, ");\n");
-
-	SkipToken(tl, ')');
-	SkipToken(tl, ';');
-}
-
-/*--------------------------------------------------------------------*/
-
 // The pp[] trick is to make the length of #name visible to flexelint.
 #define ACT(name, func, mask)						\
 	do {								\
@@ -458,7 +437,5 @@ vcc_Action_Init(struct vcc *tl)
 		VCL_MET_INIT);
 	ACT(return,	vcc_act_return,	0);
 	ACT(set,	vcc_act_set,	0);
-	ACT(synthetic,	vcc_act_synthetic,
-		VCL_MET_SYNTH | VCL_MET_BACKEND_ERROR);
 	ACT(unset,	vcc_act_unset,	0);
 }

--- a/vmod/vmod_std.vcc
+++ b/vmod/vmod_std.vcc
@@ -200,7 +200,7 @@ For binary files, use std.blobread() instead.
 
 Example::
 
-	synthetic("Response was served by " + std.fileread("/etc/hostname"));
+	set resp.body = "Response was served by " + std.fileread("/etc/hostname");
 
 Consider that the entire contents of the file appear in the string
 that is returned, including newlines that may result in invalid


### PR DESCRIPTION
## Summary

**Breaking change** -- removes the VCL `synthetic()` action and the public C API functions `VRT_synth_strands()`, `VRT_synth_blob()`, `VRT_synth_page()` and `VRT_Stv()`.

- Centralize `VRT_synth_*` implementation in `VRT_l_resp_body` (prep)
- gc duplicate `Content-Length` handling in `cnt_synth()` (prep; depends on `http_DoConnection()` from #105, hence this PR stacks on it)
- Remove VCL `synthetic()` action and `vcc_act_synthetic()`
- Remove `VRT_synth_*()` and `VRT_Stv()`

Since Varnish Cache 5.0.0, body data can be created by setting `resp.body`/`beresp.body` directly, which has been the recommended way for a long time. This removes the old `synthetic()` action and the C API it was built on. Anyone still using `synthetic()` in VCL or calling `VRT_synth_*`/`VRT_Stv` from a VMOD needs to migrate first -- see the `doc/changes.rst` entry added here for the direct replacement.

Backport of four vinyl-cache commits (part of the vinyl-tail commit-porting work tracked in #70), stacked on #105 for a real content dependency (`cnt_synth()`'s `http_DoConnection()` usage). Kept `VRT_MAJOR_VERSION` unchanged -- bumping it is a release-management call, not something to do incidentally here.

## Test plan
- [x] No dangling references to the removed symbols outside of historical changelog/version-history comments
- [x] `doc/changes.rst` and `include/vrt.h` version history merged into this repo's own already-diverged content rather than overwritten
- [ ] CI