### PR TITLE
Fix null deref in VRT_r_resp_storage

### DIFF
--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -450,7 +450,9 @@ VRT_r_resp_storage(VRT_CTX)
 	if (oc == NULL)
 		VRT_l_resp_storage(ctx, NULL);
 	oc = ctx->req->objcore;
-	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+	if (oc == NULL)
+		return (NULL);
+	CHECK_OBJ(oc, OBJCORE_MAGIC);
 	return (oc->stobj->stevedore);
 }
 

--- a/bin/vinyltest/tests/r04499.vtc
+++ b/bin/vinyltest/tests/r04499.vtc
@@ -1,0 +1,38 @@
+vtest "Reading resp.storage null deref when Synth storage exhausted"
+
+server s1 {
+	rxreq
+	expect req.url == "/fill"
+	txresp -bodylen 1048290
+} -start
+
+varnish v1 -arg "-p nuke_limit=0" -arg "-sSynth=default,1m" -vcl+backend {
+	sub vcl_recv {
+		if (req.url == "/synth") {
+			return (synth(200));
+		}
+	}
+	sub vcl_backend_response {
+		set beresp.do_stream = false;
+		set beresp.storage = storage.Synth;
+	}
+	sub vcl_synth {
+		set resp.http.X-Storage = resp.storage;
+		set resp.body = "synth body";
+		return (deliver);
+	}
+} -start
+
+client c1 {
+	txreq -url "/fill"
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -expect SMA.Synth.g_space < 200
+
+client c2 {
+	txreq -url "/synth"
+	rxresp
+	expect resp.status == 500
+} -run


### PR DESCRIPTION
When resp.storage is read in vcl_synth before any storage is
allocated, VRT_r_resp_storage() lazily calls VRT_l_resp_storage()
which may fail if storage is full. VRT_fail() logs the error but
does not stop execution, so the subsequent CHECK_OBJ_NOTNULL on
the still-NULL objcore aborts the child process.

Add a NULL guard after the lazy-init call so the VRT_fail error
path can complete gracefully (FSM sends a 500 minimal response).

Fixes https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/issues/4499

Upstream: https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/17e8f5382a6e4e113b0deffb8da01c3a18d5489c