### PR TITLE
Remove VCL synthetic() action and VRT_synth_*()/VRT_Stv()

### DIFF
--- a/bin/vinyld/cache/cache_req_fsm.c
+++ b/bin/vinyld/cache/cache_req_fsm.c
@@ -371,10 +371,6 @@ cnt_synth(struct worker *wrk, struct req *req)
 	}
 	assert(wrk->vpi->handling == VCL_RET_DELIVER);
 
-	http_Unset(req->resp, H_Content_Length);
-	http_PrintfHeader(req->resp, "Content-Length: %zd",
-	    VSB_len(synth_body));
-
 	// also happens in cnt_transmit, but we need req->doclose earlier for VRB_Ignore
 	if (req->doclose == SC_NULL)
 		req->doclose = http_DoConnection(req->http, SC_REQ_CLOSE);

--- a/bin/vinyld/cache/cache_vrt.c
+++ b/bin/vinyld/cache/cache_vrt.c
@@ -891,28 +891,30 @@ VRT_Rollback(VRT_CTX, VCL_HTTP hp)
 VCL_VOID
 VRT_synth_strands(VRT_CTX, VCL_STRANDS s)
 {
-	struct vsb *vsb;
-	int i;
+	int i, hasnull = 0;
+	const char * const s_null = "(null)";
 
-	CAST_OBJ_NOTNULL(vsb, ctx->specific, VSB_MAGIC);
 	CHECK_OBJ_NOTNULL(s, STRANDS_MAGIC);
 	for (i = 0; i < s->n; i++) {
 		if (s->p[i] != NULL)
-			VSB_cat(vsb, s->p[i]);
-		else
-			VSB_cat(vsb, "(null)");
+			continue;
+		s->p[i] = s_null;
+		hasnull = 1;
+	}
+
+	VRT_l_resp_body(ctx, LBODY_ADD_STRING, NULL, s);
+	if (hasnull == 0)
+		return;
+	for (i = 0; i < s->n; i++) {
+		if (s->p[i] == s_null)
+			s->p[i] = NULL;
 	}
 }
 
 VCL_VOID
 VRT_synth_blob(VRT_CTX, VCL_BLOB b)
 {
-	struct vsb *vsb;
-	CAST_OBJ_NOTNULL(vsb, ctx->specific, VSB_MAGIC);
-
-	CHECK_OBJ_NOTNULL(b, VRT_BLOB_MAGIC);
-	if (b->len > 0 && b->blob != NULL)
-		VSB_bcat(vsb, b->blob, b->len);
+	VRT_l_resp_body(ctx, LBODY_SET_BLOB, NULL, b);
 }
 
 VCL_VOID

--- a/bin/vinyld/cache/cache_vrt.c
+++ b/bin/vinyld/cache/cache_vrt.c
@@ -888,43 +888,6 @@ VRT_Rollback(VRT_CTX, VCL_HTTP hp)
 
 /*--------------------------------------------------------------------*/
 
-VCL_VOID
-VRT_synth_strands(VRT_CTX, VCL_STRANDS s)
-{
-	int i, hasnull = 0;
-	const char * const s_null = "(null)";
-
-	CHECK_OBJ_NOTNULL(s, STRANDS_MAGIC);
-	for (i = 0; i < s->n; i++) {
-		if (s->p[i] != NULL)
-			continue;
-		s->p[i] = s_null;
-		hasnull = 1;
-	}
-
-	VRT_l_resp_body(ctx, LBODY_ADD_STRING, NULL, s);
-	if (hasnull == 0)
-		return;
-	for (i = 0; i < s->n; i++) {
-		if (s->p[i] == s_null)
-			s->p[i] = NULL;
-	}
-}
-
-VCL_VOID
-VRT_synth_blob(VRT_CTX, VCL_BLOB b)
-{
-	VRT_l_resp_body(ctx, LBODY_SET_BLOB, NULL, b);
-}
-
-VCL_VOID
-VRT_synth_page(VRT_CTX, VCL_STRANDS s)
-{
-	VRT_synth_strands(ctx, s);
-}
-
-/*--------------------------------------------------------------------*/
-
 static VCL_STRING
 vrt_ban_error(VRT_CTX, VCL_STRING err)
 {

--- a/bin/vinyld/storage/stevedore.c
+++ b/bin/vinyld/storage/stevedore.c
@@ -283,15 +283,6 @@ stv_find(const char *nm)
 	return (NULL);
 }
 
-int
-VRT_Stv(const char *nm)
-{
-
-	if (stv_find(nm) != NULL)
-		return (1);
-	return (0);
-}
-
 const char * v_matchproto_()
 VRT_STEVEDORE_string(VCL_STEVEDORE s)
 {

--- a/bin/vinyld/storage/storage_debug.c
+++ b/bin/vinyld/storage/storage_debug.c
@@ -104,6 +104,30 @@ smd_max_extend(struct worker *wrk, struct objcore *oc, ssize_t l)
 	SML_methods.objextend(wrk, oc, l);
 }
 
+/* full storage can't get space, can't alloc objects */
+static int v_matchproto_(objgetspace_f)
+smd_full_getspace(struct worker *wrk, struct objcore *oc, ssize_t *sz,
+    uint8_t **ptr)
+{
+	(void)wrk;
+	(void)oc;
+	(void)sz;
+	(void)ptr;
+
+	return (0);
+}
+static int v_matchproto_(storage_allocobj_f)
+smd_full_allocobj(struct worker *wrk, const struct stevedore *stv,
+    struct objcore *oc, unsigned len)
+{
+	(void)wrk;
+	(void)stv;
+	(void)oc;
+	(void)len;
+
+	return (0);
+}
+
 #define dur_arg(a, s, d)					\
 	(! strncmp((a), (s), strlen(s))				\
 	 && (d = VNUM_duration(a + strlen(s))) != nan(""))
@@ -141,6 +165,7 @@ smd_init(struct stevedore *parent, int aac, char * const *aav)
 {
 	struct obj_methods *methods;
 	objgetspace_f *getspace = NULL;
+	storage_allocobj_f *allocobj = NULL;
 	const char *ident;
 	int i, ac = 0;
 	size_t nac;
@@ -169,6 +194,16 @@ smd_init(struct stevedore *parent, int aac, char * const *aav)
 	for (i = 0; i < aac; i++) {
 		a = aav[i];
 		if (a != NULL) {
+			if (! strcmp(a, "full")) {
+				if (getspace != NULL) {
+					ARGV_ERR("-s%s conflicting options\n",
+					    smd_stevedore.name);
+				}
+				getspace = smd_full_getspace;
+				AZ(allocobj);
+				allocobj = smd_full_allocobj;
+				continue;
+			}
 			if (! strcmp(a, "lessspace")) {
 				if (getspace != NULL) {
 					ARGV_ERR("-s%s conflicting options\n",
@@ -204,6 +239,8 @@ smd_init(struct stevedore *parent, int aac, char * const *aav)
 
 	if (getspace != NULL)
 		methods->objgetspace = getspace;
+	if (allocobj != NULL)
+		parent->allocobj = allocobj;
 
 	sma_stevedore.init(parent, ac, av);
 	free(av);

--- a/bin/vinyltest/tests/m00053.vtc
+++ b/bin/vinyltest/tests/m00053.vtc
@@ -84,7 +84,7 @@ varnish v1 -vcl {
 			}
 			debug.call(foo);
 		} else if (req.url == "/checkwrong") {
-			synthetic(debug.check_call(bar));
+			set resp.body = debug.check_call(bar);
 			set resp.status = 500;
 		}
 		return (deliver);

--- a/bin/vinyltest/tests/r01287.vtc
+++ b/bin/vinyltest/tests/r01287.vtc
@@ -1,4 +1,4 @@
-vtest "#1287 - check NULL as first pointer to VRT_synth_page"
+vtest "#1287 - check NULL as input to resp.body"
 
 server s1 {
 } -start
@@ -8,7 +8,7 @@ varnish v1 -vcl+backend {
 		return (synth(200, "OK"));
 	}
 	sub vcl_synth {
-		synthetic(resp.http.blank);
+		set resp.body = resp.http.blank;
 		return (deliver);
 	}
 } -start
@@ -17,5 +17,5 @@ client c1 {
 	txreq
 	rxresp
 	expect resp.status == 200
-	expect resp.body == "(null)"
+	expect resp.body == ""
 } -run

--- a/bin/vinyltest/tests/r03079.vtc
+++ b/bin/vinyltest/tests/r03079.vtc
@@ -36,9 +36,9 @@ varnish v1 -vcl {
 	}
 	sub vcl_synth {
 		if (req.url ~ "synth") {
-			synthetic("hello");
+			set resp.body = "hello";
 			if (req.url ~ "add") {
-				synthetic("world");
+				set resp.body += "world";
 			}
 		}
 		if (req.url ~ "string") {

--- a/bin/vinyltest/tests/r04499.vtc
+++ b/bin/vinyltest/tests/r04499.vtc
@@ -1,20 +1,9 @@
 vtest "Reading resp.storage null deref when Synth storage exhausted"
 
-server s1 {
-	rxreq
-	expect req.url == "/fill"
-	txresp -bodylen 1048290
-} -start
-
-varnish v1 -arg "-p nuke_limit=0" -arg "-sSynth=default,1m" -vcl+backend {
+varnish v1 -arg "-sSynth=debug,full" -vcl+backend {
+	backend none none;
 	sub vcl_recv {
-		if (req.url == "/synth") {
-			return (synth(200));
-		}
-	}
-	sub vcl_backend_response {
-		set beresp.do_stream = false;
-		set beresp.storage = storage.Synth;
+		return (synth(200));
 	}
 	sub vcl_synth {
 		set resp.http.X-Storage = resp.storage;
@@ -23,16 +12,8 @@ varnish v1 -arg "-p nuke_limit=0" -arg "-sSynth=default,1m" -vcl+backend {
 	}
 } -start
 
-client c1 {
-	txreq -url "/fill"
-	rxresp
-	expect resp.status == 200
-} -run
-
-varnish v1 -expect SMA.Synth.g_space < 200
-
 client c2 {
-	txreq -url "/synth"
+	txreq
 	rxresp
 	expect resp.status == 500
 } -run

--- a/bin/vinyltest/tests/v00018.vtc
+++ b/bin/vinyltest/tests/v00018.vtc
@@ -93,9 +93,9 @@ varnish v1 -errvcl "Symbol not found" {
 	sub vcl_recv { kluf ; }
 }
 
-varnish v1 -errvcl {Unknown token '<<' when looking for STRING} {
+varnish v1 -errvcl {Unknown token '<<' when looking for BODY} {
 	backend b { .host = "${localhost}"; }
-	sub vcl_synth { synthetic( << "foo"; }
+	sub vcl_synth { set resp.body = << "foo"; }
 }
 
 varnish v1 -errvcl {Missing argument.} {
@@ -117,7 +117,7 @@ varnish v1 -errvcl {Expected return action name.} {
 varnish v1 -errvcl {Not a valid action in subroutine 'vcl_recv'} {
 	backend foo { .host = "${localhost}"; }
 	sub vcl_recv {
-		synthetic("XXX");
+		hash_data("XXX");
 		return (synth(503));
 	}
 }

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -64,6 +64,9 @@ Varnish-Cache NEXT (unreleased)
   internally, while ``set resp.body = <nullstring>`` creates the empty string
   ``""`` and ``set resp.body += <nullstring>`` is a NOOP.
 
+* The functions ``VRT_synth_strands()``, ``VRT_synth_blob()``,
+  ``VRT_synth_page()`` and ``VRT_Stv()`` have been removed from the runtime.
+
 * ``varnish{log,ncsa,hist,top}`` all gained the ``-0`` dry-run argument that
   allows testing a command line before running it for real.
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -43,6 +43,27 @@ Varnish-Cache NEXT (unreleased)
 
 .. _VSV00019: https://vinyl-cache.org/security/VSV00019.html
 
+* The ``synthetic()`` VCL action has been removed. Since Varnish Cache 5.0.0,
+  body data can be created by setting ``beresp.body`` in ``vcl_backend_error
+  {}`` and by setting ``resp.body`` in ``vcl_synth {}``, and these continue to
+  be available as the one way to create body data, as in these examples:
+
+  - ``set resp.body = "string" + " more strings";``
+  - ``set resp.body += " appending even " + "more strings";``
+  - ``set resp.body = :blob:;``
+  - ``set resp.body += :blobappend:;``
+
+  These examples equally work on ``beresp.body`` in ``vcl_backend_error {}``.
+
+  The direct replacement for ``synthetic(<string>);`` is ``set resp.body +=
+  <string>;`` in ``vcl_synth {}`` and ``set beresp.body += <string>;`` in
+  ``vcl_backend_error {}``.
+
+  The only difference in behavior is that ``synthetic(<nullstring>)`` would
+  create the string ``(null)`` for ``<nullstring>`` being a ``NULL`` pointer
+  internally, while ``set resp.body = <nullstring>`` creates the empty string
+  ``""`` and ``set resp.body += <nullstring>`` is a NOOP.
+
 * ``varnish{log,ncsa,hist,top}`` all gained the ``-0`` dry-run argument that
   allows testing a command line before running it for real.
 

--- a/doc/sphinx/reference/vcl.rst
+++ b/doc/sphinx/reference/vcl.rst
@@ -453,14 +453,6 @@ hash_data(input)
   Adds an input to the hash input. In the built-in VCL ``hash_data()``
   is called on the host and URL of the request. Available in ``vcl_hash``.
 
-synthetic(STRING)
-~~~~~~~~~~~~~~~~~
-
-  Prepare a synthetic response body containing the *STRING*. Available
-  in ``vcl_synth`` and ``vcl_backend_error``.
-
-  Identical to ``set resp.body`` /  ``set beresp.body``.
-
 .. list above comes from struct action_table[] in vcc_action.c.
 
 regsub(str, regex, sub)

--- a/doc/sphinx/reference/vcl_step.rst
+++ b/doc/sphinx/reference/vcl_step.rst
@@ -251,9 +251,16 @@ of the following keywords:
 vcl_synth
 ~~~~~~~~~
 
-Called to deliver a synthetic object. A synthetic object is generated
-in VCL, not fetched from the backend. Its body may be constructed using
-the ``synthetic()`` function.
+Called to deliver a synthetic object. A synthetic object is generated in VCL,
+not fetched from the backend. Its body can be constructed by assigning a string
+or blob to ``resp.body`` using ``=``, or by appending a string or blob to
+``resp.body`` using ``+=``, as in these examples::
+
+  - ``set resp.body = "string";``
+  - ``set resp.body = "string " + "and another";``
+  - ``set resp.body += " appending " + "more strings";``
+  - ``set resp.body = :blob:;``
+  - ``set resp.body += :blobappend==:;``
 
 A `vcl_synth` defined object never enters the cache, contrary to a
 :ref:`vcl_backend_error` defined object, which may end up in cache.
@@ -420,19 +427,26 @@ The `vcl_backend_response` subroutine may terminate with calling
 vcl_backend_error
 ~~~~~~~~~~~~~~~~~
 
-This subroutine is called if we fail the backend fetch or if
-*max_retries* has been exceeded.
+This subroutine is called if we fail the backend fetch, if *max_retries* has
+been exceeded, or if explicitly transitioned to with ``return(error(status code,
+reason))``.
 
 Returning with :ref:`abandon` does not leave a cache object.
 
-If returning with ``deliver`` and ``beresp.uncacheable == false``, a
-synthetic cache object is generated in VCL, whose body may be constructed
-using the ``synthetic()`` function.
+If returning with ``deliver``, a synthetic body can be constructed by assigning
+a string or blob to ``beresp.body`` using ``=``, or by appending a string or
+blob to ``beresp.body`` using ``+=``, as in these examples::
 
-Since these synthetic objects are cached in these special circumstances,
-be cautious with putting private information there. If you really must,
-then you need to explicitly set ``beresp.uncacheable`` to ``true`` in
-``vcl_backend_error``.
+  - ``set beresp.body = "string";``
+  - ``set beresp.body = "string " + "and another";``
+  - ``set beresp.body += " appending " + "more strings";``
+  - ``set beresp.body = :blob:;``
+  - ``set beresp.body += :blobappend==:;``
+
+For ``return(deliver)`` with ``beresp.uncacheable == false``, the constructed
+object is cached, so be cautious with putting private information in headers or
+the body of such a cached object. When in doubt, explicitly set
+``beresp.uncacheable`` to ``true`` in ``vcl_backend_error`` to avoid caching.
 
 The `vcl_backend_error` subroutine may terminate with calling ``return()``
 with one of the following keywords:

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -59,6 +59,10 @@
  *
  * 22.2 (trunk)
  *	struct vrt_endpoint.ssl_ca_file added
+ *	VRT_synth_strands() removed
+ *	VRT_synth_blob() removed
+ *	VRT_synth_page() removed
+ *	VRT_Stv() removed
  * 22.1
  *	"vcl_name" member added to vrt_backend_probe{}
  *	VRT_PROBE_string() added
@@ -832,10 +836,6 @@ VCL_VOID VRT_hashdata(VRT_CTX, VCL_STRANDS);
 
 VCL_VOID VRT_Rollback(VRT_CTX, VCL_HTTP);
 
-/* Synthetic pages */
-VCL_VOID VRT_synth_strands(VRT_CTX, VCL_STRANDS);
-VCL_VOID VRT_synth_blob(VRT_CTX, VCL_BLOB);
-
 /***********************************************************************
  * VDI - Director API
  */
@@ -941,10 +941,3 @@ void VRT_VCL_Allow_Cold(struct vclref **);
 
 struct vclref * VRT_VCL_Prevent_Discard(VRT_CTX, const char *);
 void VRT_VCL_Allow_Discard(struct vclref **);
-
-/***********************************************************************
- * Deprecated interfaces, do not use, they will disappear at some point.
- */
-
-VCL_VOID VRT_synth_page(VRT_CTX, VCL_STRANDS);
-int VRT_Stv(const char *nm);

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -412,27 +412,6 @@ vcc_act_return(struct vcc *tl, struct token *t, struct symbol *sym)
 
 /*--------------------------------------------------------------------*/
 
-static void v_matchproto_(sym_act_f)
-vcc_act_synthetic(struct vcc *tl, struct token *t, struct symbol *sym)
-{
-
-	(void)t;
-	(void)sym;
-	ExpectErr(tl, '(');
-	ERRCHK(tl);
-	vcc_NextToken(tl);
-
-	Fb(tl, 1, "VRT_synth_strands(ctx, ");
-	vcc_Expr(tl, STRANDS);
-	ERRCHK(tl);
-	Fb(tl, 1, ");\n");
-
-	SkipToken(tl, ')');
-	SkipToken(tl, ';');
-}
-
-/*--------------------------------------------------------------------*/
-
 // The pp[] trick is to make the length of #name visible to flexelint.
 #define ACT(name, func, mask)						\
 	do {								\
@@ -458,7 +437,5 @@ vcc_Action_Init(struct vcc *tl)
 		VCL_MET_INIT);
 	ACT(return,	vcc_act_return,	0);
 	ACT(set,	vcc_act_set,	0);
-	ACT(synthetic,	vcc_act_synthetic,
-		VCL_MET_SYNTH | VCL_MET_BACKEND_ERROR);
 	ACT(unset,	vcc_act_unset,	0);
 }

--- a/vmod/vmod_std.vcc
+++ b/vmod/vmod_std.vcc
@@ -205,7 +205,7 @@ For binary files, use std.blobread() instead.
 
 Example::
 
-	synthetic("Response was served by " + std.fileread("/etc/hostname"));
+	set resp.body = "Response was served by " + std.fileread("/etc/hostname");
 
 Consider that the entire contents of the file appear in the string
 that is returned, including newlines that may result in invalid


### PR DESCRIPTION
Since Varnish Cache 5.0.0, body data can be created by setting
beresp.body in vcl_backend_error {} and by setting resp.body in
vcl_synth {}. The synthetic() VCL action and the underlying
VRT_synth_*()/VRT_Stv() runtime functions are no longer needed and
are removed here, along with a related cleanup of duplicate
Content-Length handling and a stabilization of the null-deref
regression test added for https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/issues/4499.

Upstream:
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/3b16c05a69b71d9993bd9ce529a3620140b210d3
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/addb2a59beb47dbe1a616849b7d8a25c3c34ed17
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/199daa31b0745f3f5a967dc77f78d94ea13875b8
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/ab852ba220793845a58548bc74c05e0057577d54
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/353475b092b5706945997ee52685fc4baec36fef