### PR TITLE
Add a special-purpose synth storage engine

### DIFF
--- a/bin/vinyld/Makefile.am
+++ b/bin/vinyld/Makefile.am
@@ -117,6 +117,7 @@ varnishd_SOURCES = \
 	storage/storage_malloc.c \
 	storage/storage_debug.c \
 	storage/storage_simple.c \
+	storage/storage_synth.c \
 	storage/storage_umem.c \
 	waiter/cache_waiter.c \
 	waiter/cache_waiter_epoll.c \

--- a/bin/vinyld/cache/cache_obj.h
+++ b/bin/vinyld/cache/cache_obj.h
@@ -173,7 +173,7 @@ struct obj_methods {
 	/* required */
 	objfree_f	*objfree;
 	objiterator_f	*objiterator;
-	objgetspace_f	*objgetspace;
+	objgetspace_f	*objgetspace;	// XXX add variant for synth
 	objextend_f	*objextend;
 	objgetattr_f	*objgetattr;
 	objsetattr_f	*objsetattr;

--- a/bin/vinyld/cache/cache_req_fsm.c
+++ b/bin/vinyld/cache/cache_req_fsm.c
@@ -312,7 +312,7 @@ static enum req_fsm_nxt v_matchproto_(req_state_f)
 cnt_synth(struct worker *wrk, struct req *req)
 {
 	struct vsb *synth_body;
-	ssize_t sz, szl;
+	ssize_t sz, szl = 0;
 	uint16_t status;
 	uint8_t *ptr;
 	const char *body;
@@ -379,10 +379,13 @@ cnt_synth(struct worker *wrk, struct req *req)
 
 	/* Discard any lingering request body before delivery */
 	(void)VRB_Ignore(req);
-	szl = -1;
 
-	if (req->objcore != NULL ||
-	    Resp_l_storage(req, stv_synth)) {
+	if (req->objcore == NULL)
+		(void) Resp_l_storage(req, stv_synth);
+
+	if (req->objcore == NULL)
+		szl = -1;
+	else if (req->objcore->stobj->stevedore->allocobj != ssy_stevedore.allocobj) {
 		CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
 		body = VSB_data(synth_body);
 		szl = VSB_len(synth_body);
@@ -400,10 +403,9 @@ cnt_synth(struct worker *wrk, struct req *req)
 			ObjExtend(wrk, req->objcore, sz, szl == 0 ? 1 : 0);
 			body += sz;
 		}
+		if (szl >= 0)
+			AZ(ObjSetU64(wrk, req->objcore, OA_LEN, VSB_len(synth_body)));
 	}
-
-	if (szl >= 0)
-		AZ(ObjSetU64(wrk, req->objcore, OA_LEN, VSB_len(synth_body)));
 	if (req->objcore != NULL)
 		HSH_DerefBoc(wrk, req->objcore);
 	VSB_destroy(&synth_body);

--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -1142,7 +1142,82 @@ VRT_l_##which##_body(VRT_CTX, enum lbody_e type,		\
 }
 
 VRT_BODY_L(beresp)
-VRT_BODY_L(resp)
+static VRT_BODY_L(resp_vsb)
+
+VCL_VOID
+VRT_l_resp_body(VRT_CTX, enum lbody_e type,
+    const char *str, VCL_BODY body)
+{
+	struct vscarab *scarab;
+	struct viov *viov;
+	struct req *req;
+	ssize_t sz = 0;
+	VCL_STRANDS s;
+	VCL_BLOB b;
+	int n;
+
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(body);
+	req = ctx->req;
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+
+	if (req->objcore == NULL)
+		VRT_l_resp_storage(ctx, NULL);
+	else if (type == LBODY_SET_STRING || type == LBODY_SET_BLOB)
+		VRT_l_resp_storage(ctx, req->objcore->stobj->stevedore);
+	if (req->objcore == NULL)
+		return;
+
+	AN(req->objcore->stobj->stevedore);
+	if (req->objcore->stobj->stevedore->allocobj != ssy_stevedore.allocobj) {
+		VRT_l_resp_vsb_body(ctx, type, str, body);
+		return;
+	}
+
+	if (! ObjGetSpace(req->wrk, req->objcore, &sz, (uint8_t **)(void*)&scarab)) {
+		VRT_fail(ctx, "Synth storage failed");
+		return;
+	}
+
+	VSCARAB_CHECK_NOTNULL(scarab);
+
+	if (type == LBODY_SET_BLOB || type == LBODY_ADD_BLOB) {
+		AZ(str);
+		b = body;
+		viov = VSCARAB_GET(scarab);
+		AN(viov);	// ObjGetSpace ensures
+		viov->iov.iov_base = TRUST_ME(b->blob);
+		viov->iov.iov_len = b->len;
+		return;
+	}
+	if (str != NULL) {
+		viov = VSCARAB_GET(scarab);
+		AN(viov);	// ObjGetSpace ensures
+		viov->iov.iov_base = TRUST_ME(str);
+		viov->iov.iov_len = strlen(str);
+	}
+
+	s = body;
+	for (n = 0; s != NULL && n < s->n; n++) {
+		if (s->p[n] == NULL || *s->p[n] == '\0')
+			continue;
+
+		viov = VSCARAB_GET(scarab);
+		if (viov == NULL) {
+			if (! ObjGetSpace(req->wrk, req->objcore, &sz,
+			    (uint8_t **)(void*)&scarab)) {
+				VRT_fail(ctx, "Synth storage failed");
+				return;
+			}
+			viov = VSCARAB_GET(scarab);
+		}
+		AN(viov);
+		viov->iov.iov_base = TRUST_ME(s->p[n]);
+		viov->iov.iov_len = strlen(s->p[n]);
+	}
+}
+
 
 /*--------------------------------------------------------------------*/
 

--- a/bin/vinyld/storage/mgt_stevedore.c
+++ b/bin/vinyld/storage/mgt_stevedore.c
@@ -185,6 +185,7 @@ STV_Register_The_Usual_Suspects(void)
 	STV_Register(&smf_stevedore, NULL);
 	STV_Register(&sma_stevedore, NULL);
 	STV_Register(&smd_stevedore, NULL);
+	STV_Register(&ssy_stevedore, NULL);
 #ifdef WITH_PERSISTENT_STORAGE
 	STV_Register(&smp_stevedore, NULL);
 	STV_Register(&smp_fake_stevedore, NULL);
@@ -257,7 +258,7 @@ STV_Config_Final(void)
 	if (! have_transient)
 		STV_Config(TRANSIENT_STORAGE "=default");
 	if (! have_synth)
-		STV_Config(SYNTH_STORAGE "=default");
+		STV_Config(SYNTH_STORAGE "=synth");
 }
 
 /*--------------------------------------------------------------------

--- a/bin/vinyld/storage/storage.h
+++ b/bin/vinyld/storage/storage.h
@@ -113,7 +113,7 @@ struct stevedore {
 	 */
 	storage_open_f			*open;
 	storage_close_f			*close;
-	storage_allocobj_f		*allocobj;
+	storage_allocobj_f		*allocobj;	// XXX add ws ptr or VRT_CTX?
 	storage_baninfo_f		*baninfo;
 	storage_banexport_f		*banexport;
 	storage_panic_f			*panic;
@@ -170,6 +170,7 @@ void LRU_Touch(struct worker *, struct objcore *, vtim_real now);
 /*--------------------------------------------------------------------*/
 extern const struct stevedore smu_stevedore;
 extern const struct stevedore sma_stevedore;
+extern const struct stevedore ssy_stevedore;
 extern const struct stevedore smd_stevedore;
 extern const struct stevedore smf_stevedore;
 extern const struct stevedore smp_stevedore;

--- a/bin/vinyld/storage/storage_simple.c
+++ b/bin/vinyld/storage/storage_simple.c
@@ -751,8 +751,8 @@ sml_notify_wait(struct sml_notify *sn)
 	AZ(pthread_mutex_unlock(&sn->mtx));
 }
 
-static int v_matchproto_(objiterator_f)
-sml_iterator(struct worker *wrk, struct objcore *oc,
+int v_matchproto_(objiterator_f)
+SML_iterator(struct worker *wrk, struct objcore *oc,
     void *priv, objiterate_f *func, int final)
 {
 	struct sml_notify sn;
@@ -1161,7 +1161,7 @@ sml_setattr(struct worker *wrk, struct objcore *oc, enum obj_attr attr,
 
 const struct obj_methods SML_methods = {
 	.objfree	= sml_objfree,
-	.objiterator	= sml_iterator,
+	.objiterator	= SML_iterator,
 	.objgetspace	= sml_getspace,
 	.objextend	= sml_extend,
 	.objtrimstore	= sml_trimstore,

--- a/bin/vinyld/storage/storage_simple.h
+++ b/bin/vinyld/storage/storage_simple.h
@@ -87,6 +87,8 @@ struct object *SML_MkObject(const struct stevedore *, struct objcore *,
 void *SML_AllocBuf(struct worker *, const struct stevedore *, size_t,
     uintptr_t *);
 void SML_FreeBuf(struct worker *, const struct stevedore *, uintptr_t);
+int SML_iterator(struct worker *wrk, struct objcore *oc,
+    void *priv, objiterate_f *func, int final);
 
 storage_allocobj_f SML_allocobj;
 storage_panic_f SML_panic;

--- a/bin/vinyld/storage/storage_synth.c
+++ b/bin/vinyld/storage/storage_synth.c
@@ -1,0 +1,421 @@
+/*-
+ * Copyright 2025 UPLEX - Nils Goroll Systemoptimierung
+ * All rights reserved.
+ *
+ * Author: Nils Goroll <slink@uplex.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * Special-purpose stevedore for use with transient synth objects as those
+ * created from vcl_synth {}: Does not copy, only references on-workspace
+ * data
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+
+#include "cache/cache_vinyld.h"
+
+#include "cache/cache_obj.h"
+#include "cache/cache_objhead.h"
+
+#include "storage/storage.h"
+#include "storage/storage_simple.h"
+
+#include "VSC_ssy.h"
+
+#include "vend.h"
+
+struct ssy_st {
+	unsigned			magic;
+#define	SSY_ST_MAGIC			0x236918b3
+	VSTAILQ_ENTRY(ssy_st)		list;
+	struct vscarab			scarab;
+};
+
+//lint -emacro({413}, SSY_ST_SIZE)
+#define SSY_ST_SIZE(cap) (offsetof(struct ssy_st, scarab) + VSCARAB_SIZE(cap))
+
+struct ssy {
+	unsigned			magic;
+#define SSY_MAGIC			0xfb41f362
+	unsigned			flags;
+#define SSY_F_LEN			1
+	struct ws			*ws;
+	VSTAILQ_HEAD(,ssy_st)		head;
+	// getattr needs to return *pointer* to len as big endian
+	uint8_t				len_be[sizeof(uint64_t)];
+};
+
+static struct VSC_ssy *stats = NULL;
+static struct vsc_seg *vsc_seg = NULL;
+static unsigned refcnt = 0;
+
+static void v_matchproto_(objfree_f)
+ssy_objfree(struct worker *wrk, struct objcore *oc)
+{
+
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	// object is on workspace, nothing to free here
+	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+	memset(oc->stobj, 0, sizeof *oc->stobj);
+	wrk->stats->n_object--;
+}
+
+static struct ssy_st *
+ssy_st_alloc(struct ssy *ssy)
+{
+	struct ssy_st *st;
+	const size_t cap = 8;			// XXX GOOD?
+	const size_t sz = SSY_ST_SIZE(cap);
+
+	CHECK_OBJ_NOTNULL(ssy, SSY_MAGIC);
+	st = WS_Alloc(ssy->ws, sz);
+	if (st == NULL)
+		return (st);
+	INIT_OBJ(st, SSY_ST_MAGIC);
+	VSCARAB_INIT(&st->scarab, cap);
+	VSTAILQ_INSERT_TAIL(&ssy->head, st, list);
+	return (st);
+}
+
+/*
+ * deliberate API violation: does not return space, but a VSCARAB
+ *
+ * XXX own stevedore method?
+ */
+static int v_matchproto_(objgetspace_f)
+ssy_getspace(struct worker *wrk, struct objcore *oc, ssize_t *sz,
+    uint8_t **ptr)
+{
+	struct ssy *ssy;
+	struct ssy_st *st;
+
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+	CAST_OBJ_NOTNULL(ssy, oc->stobj->priv, SSY_MAGIC);
+	(void) sz;
+
+	st = VSTAILQ_LAST(&ssy->head, ssy_st, list);
+	CHECK_OBJ_NOTNULL(st, SSY_ST_MAGIC);
+	CHECK_OBJ_NOTNULL(&st->scarab, VSCARAB_MAGIC);
+
+	if (st->scarab.used == st->scarab.capacity)
+		st = ssy_st_alloc(ssy);
+	if (st == NULL) {
+		stats->c_getspace_fail++;
+		return (0);
+	}
+	*ptr = (void*)(&st->scarab);
+	stats->c_getspace_success++;
+	return (1);
+}
+
+/*
+ * VAI for ssy is really simple because we never block, hence need no
+ * notification
+ */
+
+struct ssy_hdl {
+	struct vai_hdl_preamble	preamble;
+#define SSY_HDL_MAGIC		0x07a0be62
+	//struct ssy		*ssy;
+	struct ssy_st		*st;
+	struct viov		*viov;
+};
+
+static int
+ssy_ai_lease(struct worker *wrk, vai_hdl vhdl, struct vscarab *dst)
+{
+	struct ssy_hdl *hdl;
+	struct viov *dviov;
+	int r = 0;
+
+	(void) wrk;
+	CAST_VAI_HDL_NOTNULL(hdl, vhdl, SSY_HDL_MAGIC);
+	VSCARAB_CHECK_NOTNULL(dst);
+
+	if (hdl->st == NULL) {
+		dst->flags |= VSCARAB_F_END;
+		return (r);
+	}
+
+	CHECK_OBJ(hdl->st, SSY_ST_MAGIC);
+	VSCARAB_CHECK(&hdl->st->scarab);
+	AN(hdl->viov);
+
+	do {
+		VSCARAB_FOREACH_RESUME(hdl->viov, &hdl->st->scarab) {
+			dviov = VSCARAB_GET(dst);
+			if (dviov == NULL)
+				break;
+			*dviov = *hdl->viov;
+			dviov->lease = VAI_LEASE_NORET;
+			r++;
+		}
+		if (hdl->viov == NULL) {
+			hdl->st = VSTAILQ_NEXT(hdl->st, list);
+			if (hdl->st == NULL)
+				dst->flags |= VSCARAB_F_END;
+			else
+				hdl->viov = &hdl->st->scarab.s[0];
+		}
+	} while (hdl->viov != NULL);
+
+	return (r);
+}
+
+// just malloc
+static int
+ssy_ai_buffer(struct worker *wrk, vai_hdl vhdl, struct vscarab *scarab)
+{
+	struct ssy_hdl *hdl;
+	struct viov *vio;
+	void *p;
+	int r = 0;
+
+	(void) wrk;
+	CAST_VAI_HDL_NOTNULL(hdl, vhdl, SSY_HDL_MAGIC);
+
+	VSCARAB_FOREACH(vio, scarab)
+		if (vio->iov.iov_len == 0 || vio->iov.iov_len > UINT_MAX)
+			return (-EINVAL);
+
+	VSCARAB_FOREACH(vio, scarab) {
+		p = malloc(vio->iov.iov_len);
+		AN(p);
+		vio->iov.iov_base = p;
+		vio->lease = ptr2lease(p);
+		r++;
+	}
+	return (r);
+}
+
+// just free buffers
+static void v_matchproto_(vai_return_f)
+ssy_ai_return(struct worker *wrk, vai_hdl vhdl, struct vscaret *scaret)
+{
+	struct ssy_hdl *hdl;
+	uint64_t *p;
+
+	(void) wrk;
+	CAST_VAI_HDL_NOTNULL(hdl, vhdl, SSY_HDL_MAGIC);
+	VSCARET_CHECK_NOTNULL(scaret);
+	VSCARET_FOREACH(p, scaret) {
+		 if (*p != VAI_LEASE_NORET)
+			free (lease2ptr(*p));
+	}
+}
+
+static void v_matchproto_(vai_fini_f)
+ssy_ai_fini(struct worker *wrk, vai_hdl *vai_hdlp)
+{
+	struct ssy_hdl *hdl;
+
+	(void)wrk;
+	AN(vai_hdlp);
+	CAST_VAI_HDL_NOTNULL(hdl, *vai_hdlp, SSY_HDL_MAGIC);
+	*vai_hdlp = NULL;
+}
+
+static void * v_matchproto_(objsetattr_f)
+ssy_setattr(struct worker *wrk, struct objcore *oc, enum obj_attr attr,
+    ssize_t len, const void *ptr)
+{
+	static uint64_t ignored;
+
+	(void)wrk;
+	(void)oc;
+	assert(attr == OA_LEN);
+	(void)len;
+	(void)ptr;
+	return (&ignored);
+}
+
+static const void * v_matchproto_(objgetattr_f)
+ssy_getattr(struct worker *wrk, struct objcore *oc, enum obj_attr attr,
+   ssize_t *len)
+{
+	struct ssy *ssy;
+	struct ssy_st *st;
+	struct viov *viov;
+	static const uint8_t flags = 0;
+	uint64_t l = 0;
+
+	(void)wrk;
+	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+
+	if (attr == OA_FLAGS) {
+		AZ(len);
+		return (&flags);
+	}
+
+	if (attr != OA_LEN)
+		return (NULL);
+
+	AN(len);
+	CAST_OBJ_NOTNULL(ssy, oc->stobj->priv, SSY_MAGIC);
+	assert(attr == OA_LEN);
+
+	if ((ssy->flags & SSY_F_LEN) == 0) {
+		VSTAILQ_FOREACH(st, &ssy->head, list) {
+			VSCARAB_FOREACH(viov, &st->scarab)
+				l += viov->iov.iov_len;
+		}
+		vbe64enc(ssy->len_be, l);
+		ssy->flags |= SSY_F_LEN;
+	}
+	*len = sizeof ssy->len_be;
+	return (ssy->len_be);
+}
+
+static vai_hdl v_matchproto_(vai_init_f)
+ssy_ai_init(struct worker *wrk, struct objcore *oc, struct ws *ws,
+    vai_notify_cb *notify, void *notify_priv)
+{
+	struct ssy_hdl *hdl;
+	struct ssy *ssy;
+
+	(void)wrk;
+	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+	CAST_OBJ_NOTNULL(ssy, oc->stobj->priv, SSY_MAGIC);
+	(void)notify;
+	(void)notify_priv;
+
+	if (ws == NULL)
+		ws = ssy->ws;
+	hdl = WS_Alloc(ws, sizeof *hdl);
+	if (hdl == NULL)
+		return (NULL);
+
+	INIT_VAI_HDL(hdl, SSY_HDL_MAGIC);
+	hdl->st = VSTAILQ_FIRST(&ssy->head);
+	CHECK_OBJ(hdl->st, SSY_ST_MAGIC);
+	VSCARAB_CHECK(&hdl->st->scarab);
+	hdl->viov = &hdl->st->scarab.s[0];
+
+	AN(hdl);
+	hdl->preamble.vai_lease = ssy_ai_lease;
+	hdl->preamble.vai_buffer = ssy_ai_buffer;
+	hdl->preamble.vai_return = ssy_ai_return;
+	hdl->preamble.vai_fini = ssy_ai_fini;
+	return (hdl);
+}
+
+static const struct obj_methods ssy_methods = {
+	.objfree	= ssy_objfree,
+	.objiterator	= SML_iterator,
+	.objgetspace	= ssy_getspace,
+	.objextend	= NULL,		// don't call, asserts in cache_obj.c
+	.objtrimstore	= NULL,
+	.objbocdone	= NULL,
+	.objslim	= NULL,
+	.objgetattr	= ssy_getattr,	// only OA_LEN, OA_FLAGS, others not
+	.objsetattr	= ssy_setattr,	// only OA_LEN, ignores value
+	.objtouch	= NULL,
+	.vai_init	= ssy_ai_init
+};
+
+static int v_matchproto_(storage_allocobj_f)
+ssy_allocobj(struct worker *wrk, const struct stevedore *stv,
+    struct objcore *oc, unsigned wsl)
+{
+	struct req *req;
+	struct ssy *ssy;
+
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	CHECK_OBJ_NOTNULL(stv, STEVEDORE_MAGIC);
+	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+
+	req = THR_GetRequest();
+
+	if (wsl != 0 || req == NULL)
+		goto wrong_ctx;
+
+	CHECK_OBJ(req, REQ_MAGIC);
+	if (oc != req->objcore)
+		goto wrong_ctx;
+
+	ssy = WS_Alloc(req->ws, sizeof *ssy);
+	if (ssy == NULL)
+		goto err;
+	INIT_OBJ(ssy, SSY_MAGIC);
+	ssy->ws = req->ws;
+	VSTAILQ_INIT(&ssy->head);
+	if (ssy_st_alloc(ssy) == NULL)
+		goto err;
+	oc->stobj->stevedore = stv;
+	oc->stobj->priv = ssy;
+	stats->c_allocobj_success++;
+	return (1);
+    wrong_ctx:
+	VSLb(wrk->vsl, SLT_Error,
+	    "synth storage can only be used for resp.storage in vcl_synth {}");
+    err:
+	stats->c_allocobj_fail++;
+	return (0);
+}
+
+static void v_matchproto_(storage_close_f)
+ssy_close(const struct stevedore *st, int warn)
+{
+
+	(void)st;
+
+	ASSERT_CLI();
+	if (warn)
+		return;
+	AN(refcnt);
+	if (--refcnt > 0)
+		return;
+
+	VSC_ssy_Destroy(&vsc_seg);
+	AZ(vsc_seg);
+	stats = NULL;
+}
+
+static void v_matchproto_(storage_open_f)
+ssy_open(struct stevedore *st)
+{
+
+	(void)st;
+	ASSERT_CLI();
+	if (refcnt++ > 0)
+		return;
+
+	stats = VSC_ssy_New(NULL, &vsc_seg, "synth");
+	AN(stats);
+}
+
+const struct stevedore ssy_stevedore = {
+	.magic		=	STEVEDORE_MAGIC,
+	.name		=	"synth",
+	.vclname	=	"storage.synth",
+	.ident		=	"synth",
+	.open		=	ssy_open,
+	.close		=	ssy_close,
+	.allocobj	=	ssy_allocobj,
+	.methods	=	&ssy_methods
+};

--- a/bin/vinyltest/tests/b00017.vtc
+++ b/bin/vinyltest/tests/b00017.vtc
@@ -1,20 +1,32 @@
 vtest "Check set resp.body & storage in vcl_synth"
 
-varnish v1 -arg "-sSynth=debug,lessspace -smalloc=malloc" -vcl {
-	backend foo {
-		.host = "${bad_backend}";
-	}
+varnish v1 -arg "-sTransient=debug,lessspace" -vcl {
+	import std;
+	backend foo none;
 	sub vcl_recv {
+		if (req.url == "/cov-backend") {
+			return (hash);
+		}
+		if (req.url == "/cov-reqbody") {
+			set req.storage = storage.Synth;
+			std.cache_req_body(1M);
+		}
 		return (synth(888));
 	}
-
 	sub vcl_synth {
-		if (req.http.malloc) {
-			set resp.storage = storage.malloc;
+		if (! req.http.synth) {
+			set resp.storage = storage.Transient;
 		}
-		set resp.body = "Custom vcl_synth's body";
+		set resp.body = "Custom vcl_synth's " + now + " body";
 		set resp.http.storage = resp.storage;
 		return (deliver);
+	}
+	sub vcl_backend_fetch {
+		return (error(200));
+	}
+	sub vcl_backend_error {
+		set beresp.storage = storage.Synth;
+		set beresp.ttl = 1h;
 	}
 } -start
 
@@ -23,17 +35,29 @@ client c1 {
 	rxresp
 	expect resp.status == 888
 	expect resp.http.connection != close
-	expect resp.bodylen == 23
-	expect resp.body == "Custom vcl_synth's body"
-	expect resp.http.storage == "storage.Synth"
+	expect resp.bodylen >= 52
+	expect resp.bodylen <= 53
+	expect resp.body ~ "^Custom vcl_synth's .* body$"
+	expect resp.http.storage == "storage.Transient"
 
-	txreq -url "/" -hdr "malloc: true"
+	txreq -url "/" -hdr "synth: true"
 	rxresp
 	expect resp.status == 888
 	expect resp.http.connection != close
-	expect resp.bodylen == 23
-	expect resp.body == "Custom vcl_synth's body"
-	expect resp.http.storage == "storage.malloc"
+	expect resp.bodylen >= 52
+	expect resp.bodylen <= 53
+	expect resp.body ~ "^Custom vcl_synth's .* body$"
+	expect resp.http.storage == "storage.Synth"
+
+	txreq -url "/cov-backend"
+	rxresp
+	expect resp.status == 200
+
+	txreq -req "POST" -url "/cov-reqbody" -bodylen 64
+	rxresp
+	expect resp.status == 400
 } -run
 
 varnish v1 -expect s_synth == 2
+varnish v1 -expect SSY.synth.c_allocobj_success == 1
+varnish v1 -expect SSY.synth.c_getspace_success == 1

--- a/bin/vinyltest/tests/gh0015.vtc
+++ b/bin/vinyltest/tests/gh0015.vtc
@@ -12,6 +12,7 @@ varnish v1 -vcl {
 	}
 
 	sub vcl_synth {
+		set resp.storage = storage.Transient;
 		# Consume most of workspace_client, which should not
 		# interfere with pipelining also happening on the same
 		# workspace.

--- a/bin/vinyltest/tests/r01284.vtc
+++ b/bin/vinyltest/tests/r01284.vtc
@@ -48,7 +48,6 @@ client c1 {
 
 # Three failures, one for obj2, one for vcl_backend_error{}, one for synth objcore
 varnish v1 -expect SM?.Transient.c_fail == 2
-varnish v1 -expect SM?.Synth.c_fail == 0
 
 client c1 {
 	# Check that varnishd is still alive

--- a/bin/vinyltest/tests/r04362.vtc
+++ b/bin/vinyltest/tests/r04362.vtc
@@ -20,5 +20,5 @@ client c1 {
 	expect resp.status == 200
 } -run
 
-varnish v1 -expect transit_stored > 10240
+varnish v1 -expect transit_stored >= 10240
 varnish v1 -expect transit_buffered == 0

--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -420,12 +420,10 @@ Two special *name*\ s are:
 * ``Synth``, which is the default storage for synthetic responses created in
   ``vcl_synth {}``.
 
-  If no ``Synth`` storage is defined, the ``default`` storage is used as if
+  If no ``Synth`` storage is defined, the ``synth`` storage is used as if
   defined as::
 
-	-s Synth=default
-
-.. XXX change to synth ^^^
+	-s Synth=synth
 
 Storage *kind*\ s (stevedores) can be provided by extensions. The following
 storage *kind*\ s and options are built in:

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1984,11 +1984,10 @@ resp.storage
 	The storage backend to use for the synthetic response created in
 	vcl_synth.
 
-..      TODO
-..	Changing resp.storage deletes any synthetic body data as if ``unset
-..	resp.body`` had been called.
+	Changing resp.storage deletes any synthetic body data as if ``unset
+	resp.body`` had been called.
 
-	Defaults to storage.Transient
+	Defaults to storage.Synth
 
 .. _resp.time:
 

--- a/doc/sphinx/users-guide/storage-backends.rst
+++ b/doc/sphinx/users-guide/storage-backends.rst
@@ -262,8 +262,12 @@ Synth
 -----
 
 By default, the storage backend named "Synth" will be used for synthetic objects
-created in ``vcl_synth {}``. By default, Varnish uses an unlimited default
-backend as the ``Synth`` storage.
+created in ``vcl_synth {}``. By default, Varnish uses the ``synth``
+backend as the ``Synth`` storage, which does not copy any data.
+
+The ``Synth`` storage should only be defined to use a different backend if, for
+whatever reason, the ``synth`` backend has issues, otherwise it is considered
+optimal.
 
 Transient
 ---------

--- a/lib/libvsc/Makefile.am
+++ b/lib/libvsc/Makefile.am
@@ -14,6 +14,7 @@ VSC_SRC = \
 	VSC_sma.vsc \
 	VSC_smf.vsc \
 	VSC_smu.vsc \
+	VSC_ssy.vsc \
 	VSC_vbe.vsc \
 	VSC_vcp.vsc \
 	VSC_waiter.vsc

--- a/lib/libvsc/VSC_ssy.vsc
+++ b/lib/libvsc/VSC_ssy.vsc
@@ -1,0 +1,42 @@
+..
+	Copyright 2026 UPLEX - Nils Goroll Systemoptimierung
+	SPDX-License-Identifier: BSD-2-Clause
+	See LICENSE file for full text of license
+
+..
+	This is *NOT* a RST file but the syntax has been chosen so
+	that it may become an RST file at some later date.
+
+.. vinyl_vsc_begin::	ssy
+	:oneliner:	Synth Stevedore Counters
+	:order:		40
+
+.. vinyl_vsc:: c_allocobj_success
+	:type:	counter
+	:level:	info
+	:oneliner:	allocobj requests succeeded
+
+	Number of times an allocobj request succeeded.
+
+.. vinyl_vsc:: c_allocobj_fail
+	:type:	counter
+	:level:	info
+	:oneliner:	allocobj requests failed
+
+	Number of times an allocobj request failed.
+
+.. vinyl_vsc:: c_getspace_success
+	:type:	counter
+	:level:	info
+	:oneliner:	getspace requests succeeded
+
+	Number of times an getspace request succeeded.
+
+.. vinyl_vsc:: c_getspace_fail
+	:type:	counter
+	:level:	info
+	:oneliner:	getspace requests failed
+
+	Number of times an getspace request failed.
+
+.. vinyl_vsc_end::	ssy


### PR DESCRIPTION
Before this patch, creating a response body in vcl_synth {} involved
two memcpy to heap operations: First to a vsb, then to a storage
object.

The new "synth" storage engine simplifies this drastically in tandem
with special casing in cnt_synth() and VRT_l_resp_body(): Constituents
of the response are not copied, but rather referenced in a list of
VSCARABs, which are directly used for delivery.

Depends on the VRT_l_resp_body centralization from
https://github.com/varnish/varnish/pull/118 (synthetic() now routes
through the VSCARAB-aware write path this engine requires).

Also includes a downstream-only fix pinning gh0015.vtc's synth body to
storage.Transient, since the new default and this engine now allocate
on the client workspace, which that test deliberately exhausts.

Upstream:
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/34c563df2ae6af41f04e99314ace0b16e97ce7d0
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/53e882259d75a85688d47da38a7a986bb15d2300