### PR TITLE
Port d4057944-e9959798

### DIFF
--- a/autogen.des
+++ b/autogen.des
@@ -27,6 +27,9 @@ PERSISTENT=--with-persistent-storage
 if [ `uname -m` = "s390x" ] ; then
 	# ASLR makes this impossible
 	PERSISTENT=
+elif [ `uname -p` = "aarch64c" ] ; then
+	# CHERI(Morello)
+	PERSISTENT=
 fi
 
 rm -f $SRCDIR/configure

--- a/bin/vinyld/cache/cache.h
+++ b/bin/vinyld/cache/cache.h
@@ -808,6 +808,12 @@ struct viov {
  */
 #define IOV_NIL ((struct iovec){.iov_base = TRUST_ME(0x42), .iov_len = 0})
 
+/*
+ * rules for vscarabs:
+ * used marks the portion of the s array which is in use
+ * used viovs must not have a NULL iov_base, use IOV_NIL
+ * free viovs must be all zero (lease=0, iov_base=NULL, iov_len=0)
+ */
 struct vscarab {
 	unsigned	magic;
 #define VSCARAB_MAGIC	0x05ca7ab0

--- a/bin/vinyld/cache/cache.h
+++ b/bin/vinyld/cache/cache.h
@@ -851,6 +851,7 @@ struct vscarab {
 // declare, allocate and initialize a local VFLA
 // the additional VLA buf declaration avoids
 // "Variable-sized object may not be initialized"
+//lint -emacro(413, VFLA_LOCAL_)
 #define VFLA_LOCAL_(type, name, mag, fam, cap, bufname)				\
 	uintptr_t bufname[(VFLA_SIZE(type, fam, cap) + sizeof(uintptr_t) -1) / sizeof(uintptr_t)]; \
 	struct type *name = (void *)bufname;					\

--- a/bin/vinyld/cache/cache.h
+++ b/bin/vinyld/cache/cache.h
@@ -798,7 +798,7 @@ typedef void vai_notify_cb(vai_hdl, void *priv);
  * an array of viovs, elsewhere also called an siov or sarray
  */
 struct viov {
-	uint64_t	lease;
+	uintptr_t	lease;
 	struct iovec	iov;
 };
 
@@ -915,7 +915,7 @@ struct vscaret {
 #define VSCARET_MAGIC	0x9c1f3d7b
 	unsigned	capacity;
 	unsigned	used;
-	uint64_t	lease[] v_counted_by_(capacity);
+	uintptr_t	lease[] v_counted_by_(capacity);
 };
 
 #define VSCARET_SIZE(cap) VFLA_SIZE(vscaret, lease, cap)

--- a/bin/vinyld/cache/cache.h
+++ b/bin/vinyld/cache/cache.h
@@ -852,7 +852,7 @@ struct vscarab {
 // the additional VLA buf declaration avoids
 // "Variable-sized object may not be initialized"
 #define VFLA_LOCAL_(type, name, mag, fam, cap, bufname)				\
-	char bufname[VFLA_SIZE(type, fam, cap)];				\
+	uintptr_t bufname[(VFLA_SIZE(type, fam, cap) + sizeof(uintptr_t) -1) / sizeof(uintptr_t)]; \
 	struct type *name = (void *)bufname;					\
 	VFLA_INIT(type, name, mag, fam, cap)
 #define VFLA_LOCAL(type, name, mag, fam, cap)					\

--- a/bin/vinyld/cache/cache_filter.h
+++ b/bin/vinyld/cache/cache_filter.h
@@ -222,6 +222,9 @@ vdpio_pull(struct vdp_ctx *vdc, struct vdp_entry *vdpe, struct vscarab *scarab)
 
 	CHECK_OBJ_NOTNULL(vdc, VDP_CTX_MAGIC);
 
+	if (scarab->used == scarab->capacity)
+		return (0);
+
 	if (vdpe == NULL)
 		vdpe = VTAILQ_LAST(&vdc->vdp, vdp_entry_s);
 	else {

--- a/bin/vinyld/cache/cache_filter.h
+++ b/bin/vinyld/cache/cache_filter.h
@@ -249,6 +249,8 @@ uint64_t VDPIO_Close1(struct vdp_ctx *, struct vdp_entry *vdpe);
 static inline void
 iovec_collect(struct iovec *buf, struct iovec *out, size_t l)
 {
+	if (l == 0)
+		return;
 	if (out->iov_base == NULL)
 		out->iov_base = buf->iov_base;
 	assert((char *)out->iov_base + out->iov_len == buf->iov_base);
@@ -256,6 +258,8 @@ iovec_collect(struct iovec *buf, struct iovec *out, size_t l)
 	out->iov_len += l;
 	buf->iov_base = (char *)buf->iov_base + l;
 	buf->iov_len -= l;
+	if (buf->iov_len == 0)
+		*buf = IOV_NIL;
 }
 
 /*

--- a/bin/vinyld/cache/cache_filter.h
+++ b/bin/vinyld/cache/cache_filter.h
@@ -252,6 +252,7 @@ iovec_collect(struct iovec *buf, struct iovec *out, size_t l)
 	if (out->iov_base == NULL)
 		out->iov_base = buf->iov_base;
 	assert((char *)out->iov_base + out->iov_len == buf->iov_base);
+	assert(buf->iov_len >= l);
 	out->iov_len += l;
 	buf->iov_base = (char *)buf->iov_base + l;
 	buf->iov_len -= l;

--- a/bin/vinyld/cache/cache_filter.h
+++ b/bin/vinyld/cache/cache_filter.h
@@ -317,28 +317,46 @@ void vdpio_return_vscarab(const struct vdp_ctx *vdc, struct vscarab *scarab)
 }
 
 /*
- * return used up iovs (len == 0)
+ * return _leading_ used up iovs (len == 0)
  * move remaining to the beginning of the scarab
+ *
+ * this does not touch iovs after a non-empty iov, to support
+ * "return this lease only after iovs before have been processed" semantics
+ *
+ * should be called after a scarab has been partly consumed
  */
+
 static inline void
 vdpio_consolidate_vscarab(const struct vdp_ctx *vdc, struct vscarab *scarab)
 {
-	struct viov *v, *w;
+	struct viov *v;
+	unsigned removed;
 
 	VSCARAB_CHECK_NOTNULL(scarab);
-	w = &scarab->s[0];
-	VSCARAB_FOREACH(v, scarab) {
-		if (v->iov.iov_len == 0) {
-			AN(v->iov.iov_base);
-			vdpio_return_lease(vdc, v->lease);
-			continue;
-		}
 
-		if (v != w)
-			*w = *v;
-		w++;
+	if (scarab->used == 0 || scarab->s[0].iov.iov_len > 0)
+		return;
+
+	VSCARAB_FOREACH(v, scarab) {
+		if (v->iov.iov_len > 0)
+			break;
+		AN(v->iov.iov_base);
+		vdpio_return_lease(vdc, v->lease);
 	}
-	scarab->used = w - &scarab->s[0];
+	if (v == NULL) {
+		// all returned
+		scarab->used = 0;
+		// preserve flags
+		memset(scarab->s, 0, scarab->capacity * sizeof *v);
+		return;
+	}
+	assert(scarab->s < v);
+	removed = v - scarab->s;
+	assert(removed < scarab->used);
+	scarab->used -= removed;
+
+	memmove(scarab->s, v, scarab->used * sizeof(*v));
+	memset(scarab->s + scarab->used, 0, (scarab->capacity - scarab->used) * sizeof *v);
 }
 
 // Lifecycle management in cache_deliver_proc.c

--- a/bin/vinyld/cache/cache_lck.c
+++ b/bin/vinyld/cache/cache_lck.c
@@ -62,7 +62,7 @@ static void
 Lck_Witness_Lock(const struct ilck *il, const char *p, int l,
     const char *attempt)
 {
-	char *q, t[10];	//lint -e429
+	char *q, t[10];	//lint !e429
 	int emit;
 
 	AN(p);

--- a/bin/vinyld/cache/cache_obj.c
+++ b/bin/vinyld/cache/cache_obj.c
@@ -282,11 +282,15 @@ int
 ObjVAIbuffer(struct worker *wrk, vai_hdl vhdl, struct vscarab *scarab)
 {
 	struct vai_hdl_preamble *vaip = vhdl;
+	int r;
 
 	AN(vaip);
 	assert(vaip->magic2 == VAI_HDL_PREAMBLE_MAGIC2);
 	AN(vaip->vai_buffer);
-	return (vaip->vai_buffer(wrk, vhdl, scarab));
+	r = vaip->vai_buffer(wrk, vhdl, scarab);
+	// returning no reason for failure is a bug
+	assert(r != 0);
+	return (r);
 }
 
 void

--- a/bin/vinyld/cache/cache_range.c
+++ b/bin/vinyld/cache/cache_range.c
@@ -58,7 +58,7 @@ vrg_range_fini(struct vdp_ctx *vdc, void **priv)
 	if (vrg_priv->req->resp_len >= 0 &&
 	    vrg_priv->range_off < vrg_priv->range_high) {
 		Req_Fail(vrg_priv->req, SC_RANGE_SHORT);
-		vrg_priv->req->vdc->retval = -1;
+		vdc->retval = -1;
 	}
 	/* struct on ws, no need to free */
 	return (0);

--- a/bin/vinyld/cache/cache_range.c
+++ b/bin/vinyld/cache/cache_range.c
@@ -116,6 +116,7 @@ vrg_dorange(struct req *req, intmax_t *clen, void **priv)
 	if (low < 0 || high < 0)
 		return (NULL);		// Allow 200 response
 
+	http_Unset(req->resp, H_Content_Range);
 	if (*clen >= 0) {
 		http_PrintfHeader(req->resp, "Content-Range: bytes %jd-%jd/%jd",
 		    (intmax_t)low, (intmax_t)high, *clen);
@@ -223,6 +224,7 @@ vrg_range_init(VRT_CTX, struct vdp_ctx *vdc, void **priv)
 		return (*priv == NULL ? 1 : 0);
 
 	VSLb(vdc->vsl, SLT_Debug, "RANGE_FAIL %s", err);
+	http_Unset(ctx->req->resp, H_Content_Range);
 	if (*vdc->clen >= 0)
 		http_PrintfHeader(ctx->req->resp,
 		    "Content-Range: bytes */%jd", *vdc->clen);

--- a/bin/vinyld/cache/cache_req_body.c
+++ b/bin/vinyld/cache/cache_req_body.c
@@ -139,7 +139,11 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 				if (vfps == VFP_END)
 					flush |= OBJ_ITER_END;
 				r = func(priv, flush, ptr, l);
-				if (r)
+				// ending delivery early is not an error,
+				// continue sucking
+				if (r > 0)
+					func = NULL;
+				else if (r)
 					break;
 			} else {
 				ObjExtend(req->wrk, req->body_oc, l,
@@ -150,9 +154,11 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	} while (vfps == VFP_OK);
 	req->acct.req_bodybytes += VFP_Close(vfc);
 	VSLb_ts_req(req, "ReqBody", VTIM_real());
-	if (func != NULL) {
+	if (func != NULL || r > 0) {
 		HSH_DerefBoc(req->wrk, req->body_oc);
 		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc));
+		if (r > 0)
+			return (r);
 		if (vfps == VFP_END && r == 0 && (flush & OBJ_ITER_END) == 0)
 			r = func(priv, flush | OBJ_ITER_END, NULL, 0);
 		if (vfps != VFP_END) {

--- a/bin/vinyld/common/common_vsc.c
+++ b/bin/vinyld/common/common_vsc.c
@@ -140,11 +140,11 @@ VRT_VSC_Allocv(struct vsmw_cluster *vc, struct vsc_seg **sg,
     const unsigned char *jp, size_t sj, const char *fmt, va_list va)
 {
 	struct vsc_seg *vsg, *dvsg;
-	uintptr_t jjp;
+	uintmax_t jjp;
 
 	vsc_lock();
 
-	jjp = (uintptr_t)jp;
+	jjp = (uintmax_t)jp;	// This is a nonce
 
 	VTAILQ_FOREACH(dvsg, &vsc_seglist, list) {
 		if (dvsg->vsm != heritage.proc_vsmw)

--- a/bin/vinyld/http1/cache_http1_fetch.c
+++ b/bin/vinyld/http1/cache_http1_fetch.c
@@ -124,10 +124,11 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	}
 
 
-	// XXX H_Content_Length TODO, coming up in follow up commit with testing
 	assert(cl >= -1);
-	if (cl < 0)
+	if (cl < 0) {
+		http_Unset(hp, H_Content_Length);
 		http_ForceHeader(hp, H_Transfer_Encoding, "chunked");
+	}
 
 	VTCP_blocking(*htc->rfd);	/* XXX: we should timeout instead */
 	hdrbytes = HTTP1_Write(v1l, hp, HTTP1_Req);

--- a/bin/vinyld/http1/cache_http1_fetch.c
+++ b/bin/vinyld/http1/cache_http1_fetch.c
@@ -138,9 +138,13 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 
 	if (bo->bereq_body != NULL) {
 		AZ(bo->req);
-		assert(cl >= 0);
+		assert(cl != 0);
+		if (cl < 0)
+			V1L_Chunked(v1l);
 		(void)ObjIterate(bo->wrk, bo->bereq_body,
 		    vdc, VDP_ObjIterate, 0);
+		if (cl < 0)
+			V1L_EndChunk(v1l);
 	} else if (bo->req != NULL &&
 	    bo->req->req_body_status != BS_NONE) {
 		if (cl < 0)

--- a/bin/vinyld/http1/cache_http1_fetch.c
+++ b/bin/vinyld/http1/cache_http1_fetch.c
@@ -70,7 +70,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	uint64_t bytes, hdrbytes;
 	struct http_conn *htc;
 	struct vdp_ctx vdc[1] = {{ 0 }};
-	intmax_t cl;
+	intmax_t cl, ocl;
 	const char *err = NULL;
 	struct v1l *v1l = NULL;
 
@@ -96,7 +96,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	}
 	else
 		cl = 0;
-
+	ocl = cl;
 	VDP_Init(vdc, wrk, bo->vsl, NULL, bo, &cl);
 	if (bo->vdp_filter_list != NULL &&
 	    VCL_StackVDP(vdc, bo->vcl, bo->vdp_filter_list, NULL, bo))
@@ -128,6 +128,11 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	if (cl < 0) {
 		http_Unset(hp, H_Content_Length);
 		http_ForceHeader(hp, H_Transfer_Encoding, "chunked");
+	} else if (ocl != cl) {
+		assert(cl >= 0);
+		http_Unset(hp, H_Transfer_Encoding);
+		http_Unset(hp, H_Content_Length);
+		http_PrintfHeader(hp, "Content-Length: %ju", cl);
 	}
 
 	VTCP_blocking(*htc->rfd);	/* XXX: we should timeout instead */
@@ -136,16 +141,15 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	/* Deal with any message-body the request might (still) have */
 	i = 0;
 
-	if (bo->bereq_body != NULL) {
+	if (cl != 0 && bo->bereq_body != NULL) {
 		AZ(bo->req);
-		assert(cl != 0);
 		if (cl < 0)
 			V1L_Chunked(v1l);
 		(void)ObjIterate(bo->wrk, bo->bereq_body,
 		    vdc, VDP_ObjIterate, 0);
 		if (cl < 0)
 			V1L_EndChunk(v1l);
-	} else if (bo->req != NULL &&
+	} else if (cl != 0 && bo->req != NULL &&
 	    bo->req->req_body_status != BS_NONE) {
 		if (cl < 0)
 			V1L_Chunked(v1l);

--- a/bin/vinyld/http1/cache_http1_fetch.c
+++ b/bin/vinyld/http1/cache_http1_fetch.c
@@ -124,9 +124,10 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	}
 
 
+	// XXX H_Content_Length TODO, coming up in follow up commit with testing
 	assert(cl >= -1);
 	if (cl < 0)
-		http_PrintfHeader(hp, "Transfer-Encoding: chunked");
+		http_ForceHeader(hp, H_Transfer_Encoding, "chunked");
 
 	VTCP_blocking(*htc->rfd);	/* XXX: we should timeout instead */
 	hdrbytes = HTTP1_Write(v1l, hp, HTTP1_Req);

--- a/bin/vinyld/storage/storage.h
+++ b/bin/vinyld/storage/storage.h
@@ -77,10 +77,10 @@ typedef void sml_free_f(struct storage *);
 
 /* VAI helpers -------------------------------------------------------*/
 
-static inline uint64_t
+static inline uintptr_t
 ptr2lease(const void *ptr)
 {
-	uint64_t r = (uintptr_t)ptr;
+	uintptr_t r = (uintptr_t)ptr;
 
 	if (sizeof(void *) < 8) //lint !e506 !e774
 		r <<= 1;
@@ -89,7 +89,7 @@ ptr2lease(const void *ptr)
 }
 
 static inline void *
-lease2ptr(uint64_t l)
+lease2ptr(uintptr_t l)
 {
 
 	if (sizeof(void *) < 8) //lint !e506 !e774

--- a/bin/vinyld/storage/storage_debug.c
+++ b/bin/vinyld/storage/storage_debug.c
@@ -170,7 +170,7 @@ smd_init(struct stevedore *parent, int aac, char * const *aav)
 	int i, ac = 0;
 	size_t nac;
 	vtim_dur d, dinit = 0.0;
-	char **av;	//lint -e429
+	char **av;	//lint !e429
 	char *a;
 
 	if (count++ > 0)

--- a/bin/vinyld/storage/storage_simple.c
+++ b/bin/vinyld/storage/storage_simple.c
@@ -548,7 +548,7 @@ sml_ai_return_buffers(struct worker *wrk, vai_hdl vhdl, struct vscaret *scaret)
 {
 	struct storage *st;
 	struct sml_hdl *hdl;
-	uint64_t *p;
+	uintptr_t *p;
 
 	(void) wrk;
 	CAST_VAI_HDL_NOTNULL(hdl, vhdl, SML_HDL_MAGIC);
@@ -570,7 +570,7 @@ sml_ai_return(struct worker *wrk, vai_hdl vhdl, struct vscaret *scaret)
 {
 	struct storage *st;
 	struct sml_hdl *hdl;
-	uint64_t *p;
+	uintptr_t *p;
 
 	(void) wrk;
 	CAST_VAI_HDL_NOTNULL(hdl, vhdl, SML_HDL_MAGIC);

--- a/bin/vinyld/storage/storage_synth.c
+++ b/bin/vinyld/storage/storage_synth.c
@@ -220,7 +220,7 @@ static void v_matchproto_(vai_return_f)
 ssy_ai_return(struct worker *wrk, vai_hdl vhdl, struct vscaret *scaret)
 {
 	struct ssy_hdl *hdl;
-	uint64_t *p;
+	uintptr_t *p;
 
 	(void) wrk;
 	CAST_VAI_HDL_NOTNULL(hdl, vhdl, SSY_HDL_MAGIC);

--- a/bin/vinyld/storage/storage_synth.c
+++ b/bin/vinyld/storage/storage_synth.c
@@ -32,7 +32,7 @@
  * data
  */
 
-/*lint -e801 */
+/*lint --e{801} */
 
 #include "config.h"
 

--- a/bin/vinyld/storage/storage_synth.c
+++ b/bin/vinyld/storage/storage_synth.c
@@ -32,6 +32,8 @@
  * data
  */
 
+/*lint -e801 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/bin/vinyltest/tests/c00034.vtc
+++ b/bin/vinyltest/tests/c00034.vtc
@@ -185,6 +185,10 @@ varnish v1 -vcl+backend {
 			set beresp.do_gzip = true;
 		}
 	}
+	sub vcl_deliver {
+		# WRONG, test code code unset of Content-Range
+		set resp.http.Content-Range = "bytes 1-2/5";
+	}
 }
 
 client c4 {

--- a/bin/vinyltest/tests/m00049.vtc
+++ b/bin/vinyltest/tests/m00049.vtc
@@ -8,27 +8,7 @@ server s1 {
 	expect req.http.Transfer-Encoding == <undef>
 	expect req.body == "Cbagb Snpgb, Pnrfne Genafvg!"
 	txresp
-} -start
 
-varnish v1 -vcl+backend {
-	import debug;
-
-	sub vcl_backend_fetch {
-		set bereq.filters = "rot13 debug.pedantic";
-	}
-} -start
-
-client c1 {
-	txreq -req POST -body "Ponto Facto, Caesar Transit!"
-	rxresp
-	expect resp.status == 200
-} -run
-
-server s1 -wait
-
-# ---
-
-server s1 {
 	rxreq
 	expect req.http.Content-Length == <undef>
 	expect req.http.Transfer-Encoding == "chunked"
@@ -40,17 +20,24 @@ varnish v1 -vcl+backend {
 	import debug;
 
 	sub vcl_backend_fetch {
-		set bereq.filters = "rot13 debug.pedantic debug.chunked";
+		set bereq.filters = "rot13 debug.pedantic";
+		if (bereq.http.chunked) {
+			set bereq.filters += " debug.chunked";
+		}
 	}
-}
+} -start
 
 client c1 {
 	txreq -req POST -body "Ponto Facto, Caesar Transit!"
 	rxresp
 	expect resp.status == 200
+
+	txreq -req POST -hdr "chunked: 1" -body "Ponto Facto, Caesar Transit!"
+	rxresp
+	expect resp.status == 200
 } -run
 
-# ---
+server s1 -wait
 
 varnish v1 -vsl_catchup
 
@@ -68,8 +55,6 @@ client c1 {
 	expect resp.status == 503
 } -run
 
-
-server s1 -wait
 
 server s1 -repeat 4 {
 	rxreq

--- a/bin/vinyltest/tests/m00049.vtc
+++ b/bin/vinyltest/tests/m00049.vtc
@@ -2,7 +2,7 @@ vtest "VMOD vfp & vdp - request bodies"
 
 # this test mirrors m00048.vtc with directions reversed
 
-server s1 {
+server s1 -repeat 2 {
 	rxreq
 	expect req.http.Content-Length == "28"
 	expect req.http.Transfer-Encoding == <undef>
@@ -18,12 +18,20 @@ server s1 {
 
 varnish v1 -vcl+backend {
 	import debug;
+	import std;
+
+	sub vcl_recv {
+		if (req.http.cached) {
+			std.cache_req_body(1KB);
+		}
+	}
 
 	sub vcl_backend_fetch {
-		set bereq.filters = "rot13 debug.pedantic";
+		set bereq.filters = "rot13";
 		if (bereq.http.chunked) {
 			set bereq.filters += " debug.chunked";
 		}
+		set bereq.filters += " debug.pedantic";
 	}
 } -start
 
@@ -33,6 +41,14 @@ client c1 {
 	expect resp.status == 200
 
 	txreq -req POST -hdr "chunked: 1" -body "Ponto Facto, Caesar Transit!"
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -hdr "cached: 1" -body "Ponto Facto, Caesar Transit!"
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -hdr "cached: 1" -hdr "chunked: 1" -body "Ponto Facto, Caesar Transit!"
 	rxresp
 	expect resp.status == 200
 } -run

--- a/bin/vinyltest/tests/m00050.vtc
+++ b/bin/vinyltest/tests/m00050.vtc
@@ -1,0 +1,102 @@
+vtest "bereq.body change body length from chunked to fixed"
+
+server s1 -repeat 2 {
+	rxreq
+	expect req.http.Content-Length == "0"
+	expect req.http.Transfer-Encoding == <undef>
+	expect req.body == ""
+	txresp
+
+	rxreq
+	expect req.http.Content-Length == <undef>
+	expect req.http.Transfer-Encoding == "chunked"
+	expect req.body == ""
+	txresp
+} -start
+
+server s2 -repeat 2 {
+	rxreq
+	expect req.http.Content-Length == "3"
+	expect req.http.Transfer-Encoding == <undef>
+	expect req.body == "foo"
+	txresp
+
+	rxreq
+	expect req.http.Content-Length == <undef>
+	expect req.http.Transfer-Encoding == "chunked"
+	expect req.body == "foo"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import debug;
+	import std;
+
+	sub vcl_recv {
+		if (req.http.cached) {
+			std.cache_req_body(1KB);
+		}
+	}
+
+	sub vcl_backend_fetch {
+		if (bereq.http.body) {
+			debug.body_string(bereq.http.body);
+			set bereq.backend = s2;
+		}
+		set bereq.filters = "debug.string";
+		if (bereq.http.chunked) {
+			set bereq.filters += " debug.chunked";
+		}
+		set bereq.filters += " debug.pedantic";
+	}
+} -start
+
+client c1 {
+	txreq -req POST -nolen -hdr "Transfer-Encoding: chunked"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunkedlen 0
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -nolen -hdr "chunked: 1" -hdr "Transfer-Encoding: chunked"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunkedlen 0
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -nolen -hdr "cached: 1" -hdr "Transfer-Encoding: chunked"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunkedlen 0
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -nolen -hdr "cached: 1" -hdr "chunked: 1" -hdr "Transfer-Encoding: chunked"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunkedlen 0
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -hdr "body: foo" -nolen -hdr "Transfer-Encoding: chunked"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunkedlen 0
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -hdr "body: foo" -nolen -hdr "chunked: 1" -hdr "Transfer-Encoding: chunked"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunkedlen 0
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -hdr "body: foo" -nolen -hdr "cached: 1" -hdr "Transfer-Encoding: chunked"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunkedlen 0
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -hdr "body: foo" -nolen -hdr "cached: 1" -hdr "chunked: 1" -hdr "Transfer-Encoding: chunked"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunkedlen 0
+	rxresp
+	expect resp.status == 200
+} -run

--- a/bin/vinyltest/tests/m00050.vtc
+++ b/bin/vinyltest/tests/m00050.vtc
@@ -54,11 +54,39 @@ varnish v1 -vcl+backend {
 client c1 {
 	txreq -req POST -nolen -hdr "Transfer-Encoding: chunked"
 	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
 	chunkedlen 0
 	rxresp
 	expect resp.status == 200
 
 	txreq -req POST -nolen -hdr "chunked: 1" -hdr "Transfer-Encoding: chunked"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
+	chunked "Ponto Facto, Caesar Transit!"
 	chunked "Ponto Facto, Caesar Transit!"
 	chunkedlen 0
 	rxresp

--- a/include/vsc_priv.h
+++ b/include/vsc_priv.h
@@ -44,5 +44,5 @@
 struct vsc_head {
 	volatile int		ready;
 	uint64_t		body_offset;
-	uintptr_t		doc_id;
+	uintmax_t		doc_id;
 };

--- a/include/vtree.h
+++ b/include/vtree.h
@@ -1,9 +1,8 @@
 /*	$NetBSD: tree.h,v 1.8 2004/03/28 19:38:30 provos Exp $	*/
 /*	$OpenBSD: tree.h,v 1.7 2002/10/17 21:51:54 art Exp $	*/
-/* $FreeBSD$ */
 
 /*-
- * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright 2002 Niels Provos <provos@citi.umich.edu>
  * All rights reserved.
@@ -321,7 +320,7 @@ struct name {								\
 	(root)->rbh_root = NULL;					\
 } while (/*CONSTCOND*/ 0)
 
-#define VRBT_ENTRY(type)							\
+#define VRBT_ENTRY(type)						\
 struct {								\
 	struct type *rbe_link[3];					\
 }
@@ -337,24 +336,27 @@ struct {								\
 #define _VRBT_UP(elm, field)		_VRBT_LINK(elm, 0, field)
 #define _VRBT_L				((uintptr_t)1)
 #define _VRBT_R				((uintptr_t)2)
-#define _VRBT_LR				((uintptr_t)3)
-#define _VRBT_BITS(elm)			(*(uintptr_t *)&elm)
-#define _VRBT_BITSUP(elm, field)		_VRBT_BITS(_VRBT_UP(elm, field))
-#define _VRBT_PTR(elm)			(__typeof(elm))			\
-					((uintptr_t)elm & ~_VRBT_LR)
+#define _VRBT_LR			((uintptr_t)3)
+#define _VRBT_BITS(elm)			((uintptr_t)elm)
+#define _VRBT_BITSUP(elm, field)	_VRBT_BITS(_VRBT_UP(elm, field))
+#define _VRBT_PTR_OP(elm, op, dir)	((__typeof(elm))		\
+					((uintptr_t)(elm) op (dir)))
+#define _VRBT_PTR(elm)			_VRBT_PTR_OP((elm), &, ~_VRBT_LR)
+#define _VRBT_MOD_OR(elm, dir)		((elm) = _VRBT_PTR_OP((elm), |, (dir)))
+#define _VRBT_MOD_XOR(elm, dir)		((elm) = _VRBT_PTR_OP((elm), ^, (dir)))
 
 #define VRBT_PARENT(elm, field)		_VRBT_PTR(_VRBT_UP(elm, field))
 #define VRBT_LEFT(elm, field)		_VRBT_LINK(elm, _VRBT_L, field)
 #define VRBT_RIGHT(elm, field)		_VRBT_LINK(elm, _VRBT_R, field)
 #define VRBT_ROOT(head)			(head)->rbh_root
-#define VRBT_EMPTY(head)			(VRBT_ROOT(head) == NULL)
+#define VRBT_EMPTY(head)		(VRBT_ROOT(head) == NULL)
 
 #define VRBT_SET_PARENT(dst, src, field) do {				\
-	_VRBT_BITSUP(dst, field) = (uintptr_t)src |			\
-	    (_VRBT_BITSUP(dst, field) & _VRBT_LR);				\
+	_VRBT_UP(dst, field) = (__typeof(src))((uintptr_t)src |		\
+	    (_VRBT_BITSUP(dst, field) & _VRBT_LR));			\
 } while (/*CONSTCOND*/ 0)
 
-#define VRBT_SET(elm, parent, field) do {					\
+#define VRBT_SET(elm, parent, field) do {				\
 	_VRBT_UP(elm, field) = parent;					\
 	VRBT_LEFT(elm, field) = VRBT_RIGHT(elm, field) = NULL;		\
 } while (/*CONSTCOND*/ 0)
@@ -550,13 +552,13 @@ name##_VRBT_INSERT_COLOR(struct name *head,				\
 		elmdir = VRBT_RIGHT(parent, field) == elm ? _VRBT_R : _VRBT_L; \
 		if (_VRBT_BITS(gpar) & elmdir) {				\
 			/* shorten the parent-elm edge to rebalance */	\
-			_VRBT_BITSUP(parent, field) ^= elmdir;		\
+			_VRBT_MOD_XOR(_VRBT_UP(parent, field), elmdir);	\
 			return (NULL);					\
 		}							\
 		sibdir = elmdir ^ _VRBT_LR;				\
 		/* the other edge must change length */			\
-		_VRBT_BITSUP(parent, field) ^= sibdir;			\
-		if ((_VRBT_BITS(gpar) & _VRBT_LR) == 0) {			\
+		_VRBT_MOD_XOR(_VRBT_UP(parent, field), sibdir);		\
+		if ((_VRBT_BITS(gpar) & _VRBT_LR) == 0) {		\
 			/* both edges now short, retry from parent */	\
 			child = elm;					\
 			elm = parent;					\
@@ -587,11 +589,14 @@ name##_VRBT_INSERT_COLOR(struct name *head,				\
 			VRBT_ROTATE(elm, child, elmdir, field);		\
 			child_up = _VRBT_UP(child, field);		\
 			if (_VRBT_BITS(child_up) & sibdir)		\
-				_VRBT_BITSUP(parent, field) ^= elmdir;	\
+				_VRBT_MOD_XOR(_VRBT_UP(parent, field),	\
+				    elmdir);				\
 			if (_VRBT_BITS(child_up) & elmdir)		\
-				_VRBT_BITSUP(elm, field) ^= _VRBT_LR;	\
+				_VRBT_MOD_XOR(_VRBT_UP(elm, field),	\
+				    _VRBT_LR);				\
 			else						\
-				_VRBT_BITSUP(elm, field) ^= elmdir;	\
+				_VRBT_MOD_XOR(_VRBT_UP(elm, field),	\
+				    elmdir);				\
 			/* if child is a leaf, don't augment elm,	\
 			 * since it is restored to be a leaf again. */	\
 			if ((_VRBT_BITS(child_up) & _VRBT_LR) == 0)		\
@@ -660,23 +665,23 @@ name##_VRBT_REMOVE_COLOR(struct name *head,				\
 		/* the rank of the tree rooted at elm shrank */		\
 		gpar = _VRBT_UP(parent, field);				\
 		elmdir = VRBT_RIGHT(parent, field) == elm ? _VRBT_R : _VRBT_L; \
-		_VRBT_BITS(gpar) ^= elmdir;				\
-		if (_VRBT_BITS(gpar) & elmdir) {				\
+		_VRBT_MOD_XOR(gpar, elmdir);				\
+		if (_VRBT_BITS(gpar) & elmdir) {			\
 			/* lengthen the parent-elm edge to rebalance */	\
 			_VRBT_UP(parent, field) = gpar;			\
 			return (NULL);					\
 		}							\
-		if (_VRBT_BITS(gpar) & _VRBT_LR) {				\
+		if (_VRBT_BITS(gpar) & _VRBT_LR) {			\
 			/* shorten other edge, retry from parent */	\
-			_VRBT_BITS(gpar) ^= _VRBT_LR;			\
+			_VRBT_MOD_XOR(gpar, _VRBT_LR);			\
 			_VRBT_UP(parent, field) = gpar;			\
 			gpar = _VRBT_PTR(gpar);				\
 			continue;					\
 		}							\
 		sibdir = elmdir ^ _VRBT_LR;				\
-		sib = _VRBT_LINK(parent, sibdir, field);			\
+		sib = _VRBT_LINK(parent, sibdir, field);		\
 		up = _VRBT_UP(sib, field);				\
-		_VRBT_BITS(up) ^= _VRBT_LR;					\
+		_VRBT_MOD_XOR(up, _VRBT_LR);				\
 		if ((_VRBT_BITS(up) & _VRBT_LR) == 0) {			\
 			/* shorten edges descending from sib, retry */	\
 			_VRBT_UP(sib, field) = up;			\
@@ -707,24 +712,29 @@ name##_VRBT_REMOVE_COLOR(struct name *head,				\
 			/* elm is a 1-child.  First rotate at elm. */	\
 			VRBT_ROTATE(sib, elm, sibdir, field);		\
 			up = _VRBT_UP(elm, field);			\
-			_VRBT_BITSUP(parent, field) ^=			\
-			    (_VRBT_BITS(up) & elmdir) ? _VRBT_LR : elmdir;	\
-			_VRBT_BITSUP(sib, field) ^=			\
-			    (_VRBT_BITS(up) & sibdir) ? _VRBT_LR : sibdir;	\
-			_VRBT_BITSUP(elm, field) |= _VRBT_LR;		\
+			_VRBT_MOD_XOR(_VRBT_UP(parent, field),		\
+			    (_VRBT_BITS(up) & elmdir) ? _VRBT_LR : elmdir);	\
+			_VRBT_MOD_XOR(_VRBT_UP(sib, field),		\
+			    (_VRBT_BITS(up) & sibdir) ? _VRBT_LR : sibdir);	\
+			_VRBT_MOD_OR(_VRBT_UP(elm, field), _VRBT_LR);	\
 		} else {						\
 			if ((_VRBT_BITS(up) & elmdir) == 0 &&		\
 			    VRBT_STRICT_HST && elm != NULL) {		\
 				/* if parent does not become a leaf,	\
 				   do not demote parent yet. */		\
-				_VRBT_BITSUP(parent, field) ^= sibdir;	\
-				_VRBT_BITSUP(sib, field) ^= _VRBT_LR;	\
+				_VRBT_MOD_XOR(_VRBT_UP(parent, field),	\
+				    sibdir);				\
+				_VRBT_MOD_XOR(_VRBT_UP(sib, field),	\
+				    _VRBT_LR);				\
 			} else if ((_VRBT_BITS(up) & elmdir) == 0) {	\
 				/* demote parent. */			\
-				_VRBT_BITSUP(parent, field) ^= elmdir;	\
-				_VRBT_BITSUP(sib, field) ^= sibdir;	\
+				_VRBT_MOD_XOR(_VRBT_UP(parent, field),	\
+				    elmdir);				\
+				_VRBT_MOD_XOR(_VRBT_UP(sib, field),	\
+				    sibdir);				\
 			} else						\
-				_VRBT_BITSUP(sib, field) ^= sibdir;	\
+				_VRBT_MOD_XOR(_VRBT_UP(sib, field),	\
+				    sibdir);				\
 			elm = sib;					\
 		}							\
 									\

--- a/include/vtree.h
+++ b/include/vtree.h
@@ -74,6 +74,11 @@
  * The maximum height of a rank-balanced tree is 2lg (n+1).
  */
 
+#ifndef __CHERI__
+#  define __no_subobject_bounds /* */
+#  define ptraddr_t uintptr_t
+#endif
+
 #define VSPLAY_HEAD(name, type)						\
 struct name {								\
 	struct type *sph_root; /* root of the tree */			\
@@ -88,8 +93,8 @@ struct name {								\
 
 #define VSPLAY_ENTRY(type)						\
 struct {								\
-	struct type *spe_left; /* left element */			\
-	struct type *spe_right; /* right element */			\
+	struct type *spe_left __no_subobject_bounds; /* left element */	\
+	struct type *spe_right __no_subobject_bounds; /* right element */ \
 }
 
 #define VSPLAY_LEFT(elm, field)		(elm)->field.spe_left
@@ -322,7 +327,7 @@ struct name {								\
 
 #define VRBT_ENTRY(type)						\
 struct {								\
-	struct type *rbe_link[3];					\
+	struct type *rbe_link[3] __no_subobject_bounds;			\
 }
 
 /*
@@ -334,10 +339,10 @@ struct {								\
  */
 #define _VRBT_LINK(elm, dir, field)	(elm)->field.rbe_link[dir]
 #define _VRBT_UP(elm, field)		_VRBT_LINK(elm, 0, field)
-#define _VRBT_L				((uintptr_t)1)
-#define _VRBT_R				((uintptr_t)2)
-#define _VRBT_LR			((uintptr_t)3)
-#define _VRBT_BITS(elm)			((uintptr_t)elm)
+#define _VRBT_L				((ptraddr_t)1)
+#define _VRBT_R				((ptraddr_t)2)
+#define _VRBT_LR			((ptraddr_t)3)
+#define _VRBT_BITS(elm)			((ptraddr_t)elm)
 #define _VRBT_BITSUP(elm, field)	_VRBT_BITS(_VRBT_UP(elm, field))
 #define _VRBT_PTR_OP(elm, op, dir)	((__typeof(elm))		\
 					((uintptr_t)(elm) op (dir)))
@@ -353,7 +358,7 @@ struct {								\
 
 #define VRBT_SET_PARENT(dst, src, field) do {				\
 	_VRBT_UP(dst, field) = (__typeof(src))((uintptr_t)src |		\
-	    (_VRBT_BITSUP(dst, field) & _VRBT_LR));			\
+	    (ptraddr_t)(_VRBT_BITSUP(dst, field) & _VRBT_LR));		\
 } while (/*CONSTCOND*/ 0)
 
 #define VRBT_SET(elm, parent, field) do {				\
@@ -543,8 +548,8 @@ name##_VRBT_INSERT_COLOR(struct name *head,				\
 	 * when a value has been assigned to 'child' in the previous    \
 	 * one.								\
 	 */								\
-	struct type *child = NULL, *child_up, *gpar;				\
-	uintptr_t elmdir, sibdir;					\
+	struct type *child = NULL, *child_up, *gpar;			\
+	ptraddr_t elmdir, sibdir;					\
 									\
 	do {								\
 		/* the rank of the tree rooted at elm grew */		\
@@ -650,7 +655,7 @@ name##_VRBT_REMOVE_COLOR(struct name *head,				\
     struct type *parent, struct type *elm)				\
 {									\
 	struct type *gpar, *sib, *up;					\
-	uintptr_t elmdir, sibdir;					\
+	ptraddr_t elmdir, sibdir;					\
 									\
 	if (VRBT_RIGHT(parent, field) == elm &&				\
 	    VRBT_LEFT(parent, field) == elm) {				\

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -511,6 +511,10 @@ $Restrict vcl_deliver
 Switch to the VAI http1 debug transport. Calling it from any other
 transport than http1 results in VCL failure.
 
+$Function VOID body_string(STRING)
+
+Set the string to send as the body with the ``debug.string`` filter.
+
 DEPRECATED
 ==========
 

--- a/vmod/vmod_debug_filters.c
+++ b/vmod/vmod_debug_filters.c
@@ -788,6 +788,76 @@ static const struct vdp xyzzy_vdp_awshog = {
 	.init  = xyzzy_awshog_init
 };
 
+/**********************************************************************
+ * send a fixed string
+ */
+
+static const void * const string_priv_id = &string_priv_id;
+
+static int v_matchproto_(vdp_init_f)
+xyzzy_string_init(VRT_CTX, struct vdp_ctx *vdc, void **priv)
+{
+	struct vmod_priv *p;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(vdc, VDP_CTX_MAGIC);
+	CHECK_OBJ_ORNULL(vdc->oc, OBJCORE_MAGIC);
+	CHECK_OBJ_NOTNULL(vdc->hp, HTTP_MAGIC);
+	AN(vdc->clen);
+
+	AN(priv);
+	p = VRT_priv_task_get(ctx, string_priv_id);
+	if (p == NULL || p->priv == NULL) {
+		*priv = TRUST_ME("");
+		*vdc->clen = 0;
+		return (0);
+	}
+	AN(p->priv);
+	*priv = p->priv;
+	*vdc->clen = strlen(*priv);
+	return (0);
+}
+
+static int v_matchproto_(vdp_bytes_f)
+xyzzy_string_bytes(struct vdp_ctx *vdc, enum vdp_action act, void **priv,
+    const void *ptr, ssize_t len)
+{
+
+	(void)act;
+	AN(priv);
+	(void)ptr;
+	(void)len;
+	return (VDP_bytes(vdc, VDP_END, *priv, strlen(*priv)));
+}
+
+static int v_matchproto_(vdp_fini_f)
+xyzzy_string_fini(struct vdp_ctx *vdc, void **priv)
+{
+	(void)vdc;
+	AN(priv);
+	*priv = NULL;
+	return (0);
+}
+
+static const struct vdp xyzzy_vdp_string = {
+	.name  = "debug.string",
+	.init  = xyzzy_string_init,
+	.bytes = xyzzy_string_bytes,
+	.fini = xyzzy_string_fini,
+};
+
+VCL_VOID v_matchproto_(td_xyzzy_debug_body_string)
+xyzzy_body_string(VRT_CTX, VCL_STRING s)
+{
+	struct vmod_priv *p;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	p = VRT_priv_task(ctx, string_priv_id);
+	if (p == NULL)
+		return;
+	p->priv = TRUST_ME(s);
+}
+
 void
 debug_add_filters(VRT_CTX)
 {
@@ -799,6 +869,7 @@ debug_add_filters(VRT_CTX)
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_chkcrc32));
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_chklen));
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_awshog));
+	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_string));
 }
 
 void
@@ -812,4 +883,5 @@ debug_remove_filters(VRT_CTX)
 	VRT_RemoveFilter(ctx, NULL, &xyzzy_vdp_chkcrc32);
 	VRT_RemoveFilter(ctx, NULL, &xyzzy_vdp_chklen);
 	VRT_RemoveFilter(ctx, NULL, &xyzzy_vdp_awshog);
+	VRT_RemoveFilter(ctx, NULL, &xyzzy_vdp_string);
 }

--- a/vmod/vmod_debug_filters.c
+++ b/vmod/vmod_debug_filters.c
@@ -822,12 +822,18 @@ static int v_matchproto_(vdp_bytes_f)
 xyzzy_string_bytes(struct vdp_ctx *vdc, enum vdp_action act, void **priv,
     const void *ptr, ssize_t len)
 {
+	int r;
 
 	(void)act;
 	AN(priv);
 	(void)ptr;
 	(void)len;
-	return (VDP_bytes(vdc, VDP_END, *priv, strlen(*priv)));
+
+	r = VDP_bytes(vdc, VDP_END, *priv, strlen(*priv));
+	if (r != 0)
+		return (r);
+	// only to be called once
+	return (1);
 }
 
 static int v_matchproto_(vdp_fini_f)

--- a/vmod/vmod_debug_filters.c
+++ b/vmod/vmod_debug_filters.c
@@ -792,10 +792,10 @@ static const struct vdp xyzzy_vdp_awshog = {
 void
 debug_add_filters(VRT_CTX)
 {
+	AZ(VRT_AddFilter(ctx, &xyzzy_vfp_slow, &xyzzy_vdp_slow));
 	AZ(VRT_AddFilter(ctx, &xyzzy_vfp_rot13, &xyzzy_vdp_rot13));
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_pedantic));
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_chunked));
-	AZ(VRT_AddFilter(ctx, &xyzzy_vfp_slow, &xyzzy_vdp_slow));
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_chksha256));
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_chkcrc32));
 	AZ(VRT_AddFilter(ctx, NULL, &xyzzy_vdp_chklen));

--- a/vmod/vmod_debug_filters.c
+++ b/vmod/vmod_debug_filters.c
@@ -195,7 +195,6 @@ xyzzy_vdp_chunked_init(VRT_CTX, struct vdp_ctx *vdc, void **priv)
 	AN(vdc->clen);
 	AN(priv);
 
-	http_Unset(vdc->hp, H_Content_Length);
 	*vdc->clen = -1;
 
 	return (1);

--- a/vmod/vmod_directors_shard_dir.c
+++ b/vmod/vmod_directors_shard_dir.c
@@ -30,7 +30,7 @@
  * SUCH DAMAGE.
  */
 
-/*lint -e801 */
+/*lint --e{801} */
 
 #include "config.h"
 


### PR DESCRIPTION
full VDPIO/CHERI polish series plus the request/response body
length transition work (filters changing body length between fixed,
unknown, and chunked), and the two vdp_string_bytes / VRB_pull fixes
that were the original motivation for looking at this block.

Upstream range: e9959798164903b4e3f86ea5e7b00ff45aa8f1f9..d4057944371f79c66ff70b446123ceaeb6ddf2ec