### PR TITLE
Prepare the req / bereq / req_bereq macros and tables for resp variables

### DIFF
--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -929,7 +929,6 @@ VRT_r_sess_xid(VRT_CTX)
  * req fields
  */
 
-#define VREQW0(field)
 #define VREQWreq(field)							\
 VCL_VOID								\
 VRT_l_req_##field(VRT_CTX, VCL_BOOL a)					\
@@ -939,7 +938,6 @@ VRT_l_req_##field(VRT_CTX, VCL_BOOL a)					\
 	ctx->req->field = a ? 1 : 0;					\
 }
 
-#define VREQR0(field)
 #define VREQRreq(field)							\
 VCL_BOOL								\
 VRT_r_req_##field(VRT_CTX)						\
@@ -948,6 +946,9 @@ VRT_r_req_##field(VRT_CTX)						\
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);				\
 	return (ctx->req->field);					\
 }
+
+#define VREQW0(field)
+#define VREQR0(field)
 
 #define REQ_FLAG(l, r, w, d) \
 	VREQR##r(l) \

--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -926,21 +926,21 @@ VRT_r_sess_xid(VRT_CTX)
 }
 
 /*--------------------------------------------------------------------
- * req fields
+ * req/resp fields, both stored in struct req
  */
 
-#define VREQWreq(field)							\
+#define VREQW(where, field)						\
 VCL_VOID								\
-VRT_l_req_##field(VRT_CTX, VCL_BOOL a)					\
+VRT_l_##where##_##field(VRT_CTX, VCL_BOOL a)				\
 {									\
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);				\
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);				\
 	ctx->req->field = a ? 1 : 0;					\
 }
 
-#define VREQRreq(field)							\
+#define VREQR(where, field)						\
 VCL_BOOL								\
-VRT_r_req_##field(VRT_CTX)						\
+VRT_r_##where##_##field(VRT_CTX)					\
 {									\
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);				\
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);				\
@@ -949,11 +949,25 @@ VRT_r_req_##field(VRT_CTX)						\
 
 #define VREQW0(field)
 #define VREQR0(field)
+#define VREQWreq(field)		VREQW(req, field)
+#define VREQRreq(field)		VREQR(req, field)
+#define VREQWresp(field)	VREQW(resp, field)
+#define VREQRresp(field)	VREQR(resp, field)
 
 #define REQ_FLAG(l, r, w, d) \
 	VREQR##r(l) \
 	VREQW##w(l)
 #include "tbl/req_flags.h"
+
+#undef VREQW
+#undef VREQR
+#undef VREQW0
+#undef VREQR0
+#undef VREQWreq
+#undef VREQRreq
+#undef VREQWresp
+#undef VREQRresp
+
 
 /*--------------------------------------------------------------------*/
 

--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -212,10 +212,12 @@ VRT_r_beresp_##field(VRT_CTX)						\
 
 /*--------------------------------------------------------------------
  * bereq bool-fields
+ *
+ * for macro compatiblity with the client side, r is "req" for bereq
  */
 
 #define VBEREQR0(field, str)
-#define VBEREQR1(field, str)						\
+#define VBEREQRreq(field, str)						\
 VCL_BOOL								\
 VRT_r_bereq_##field(VRT_CTX)						\
 {									\
@@ -229,7 +231,7 @@ VRT_r_bereq_##field(VRT_CTX)						\
 #include "tbl/bereq_flags.h"
 
 #undef VBEREQR0
-#undef VBEREQR1
+#undef VBEREQRreq
 /*--------------------------------------------------------------------*/
 
 VCL_BOOL
@@ -928,7 +930,7 @@ VRT_r_sess_xid(VRT_CTX)
  */
 
 #define VREQW0(field)
-#define VREQW1(field)							\
+#define VREQWreq(field)							\
 VCL_VOID								\
 VRT_l_req_##field(VRT_CTX, VCL_BOOL a)					\
 {									\
@@ -938,7 +940,7 @@ VRT_l_req_##field(VRT_CTX, VCL_BOOL a)					\
 }
 
 #define VREQR0(field)
-#define VREQR1(field)							\
+#define VREQRreq(field)							\
 VCL_BOOL								\
 VRT_r_req_##field(VRT_CTX)						\
 {									\

--- a/include/tbl/bereq_flags.h
+++ b/include/tbl/bereq_flags.h
@@ -32,8 +32,8 @@
 /*lint -save -e525 -e539 */
 
 /* lower, vcl_r, vcl_w, doc */
-BEREQ_FLAG(uncacheable,	0, 0, "")	// also beresp
-BEREQ_FLAG(is_bgfetch,	1, 0, "")
+BEREQ_FLAG(uncacheable,	0,   0, "")	// also beresp
+BEREQ_FLAG(is_bgfetch,	req, 0, "")
 #define REQ_BEREQ_FLAG(lower, vcl_r, vcl_w, doc) \
 	BEREQ_FLAG(lower, vcl_r, vcl_w, doc)
 #include "tbl/req_bereq_flags.h"

--- a/include/tbl/req_bereq_flags.h
+++ b/include/tbl/req_bereq_flags.h
@@ -32,9 +32,9 @@
 /*lint -save -e525 -e539 */
 
 /* lower, vcl_r, vcl_w, doc */
-REQ_BEREQ_FLAG(is_hitmiss,		1, 0, "")
-REQ_BEREQ_FLAG(is_hitpass,		1, 0, "")
-REQ_BEREQ_FLAG(trace,			1, 0, "")
+REQ_BEREQ_FLAG(is_hitmiss,		req, 0, "")
+REQ_BEREQ_FLAG(is_hitpass,		req, 0, "")
+REQ_BEREQ_FLAG(trace,			req, 0, "")
 #undef REQ_BEREQ_FLAG
 
 /*lint -restore */

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -32,16 +32,16 @@
 /*lint -save -e525 -e539 */
 
 /* lower, vcl_r, vcl_w, doc */
-REQ_FLAG(disable_esi,		0, 0, "")
-REQ_FLAG(hash_ignore_busy,	1, 1, "")
-REQ_FLAG(hash_ignore_vary,	1, 1, "")
-REQ_FLAG(hash_always_miss,	1, 1, "")
-REQ_FLAG(is_hit,		0, 0, "")
-REQ_FLAG(want100cont,		0, 0, "")
-REQ_FLAG(late100cont,		0, 0, "")
-REQ_FLAG(req_reset,		0, 0, "")
-REQ_FLAG(res_esi,		0, 0, "")
-REQ_FLAG(res_pipe,		0, 0, "")
+REQ_FLAG(disable_esi,		0,    0,    "")
+REQ_FLAG(hash_ignore_busy,	req,  req,  "")
+REQ_FLAG(hash_ignore_vary,	req,  req,  "")
+REQ_FLAG(hash_always_miss,	req,  req,  "")
+REQ_FLAG(is_hit,		0,    0,    "")
+REQ_FLAG(want100cont,		0,    0,    "")
+REQ_FLAG(late100cont,		0,    0,    "")
+REQ_FLAG(req_reset,		0,    0,    "")
+REQ_FLAG(res_esi,		0,    0,    "")
+REQ_FLAG(res_pipe,		0,    0,    "")
 #define REQ_BEREQ_FLAG(lower, vcl_r, vcl_w, doc) \
 	REQ_FLAG(lower, vcl_r, vcl_w, doc)
 #include "tbl/req_bereq_flags.h"


### PR DESCRIPTION
vcl_r and vcl_w are now wither "0" for "do not generate vrt" or "req" for "do".

"resp" will be added

Motivated by https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/issues/4054

Upstream:
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/9212599373861ef89cdb58b298b732a1c43ff8a9
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/bb1993b3bf154bc0f3a3279d80e87b349c8ee28c
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/80c1f28402be75fb54f0f436629353e89ccff560