### PR TITLE
Use vstrcmp()

### DIFF
--- a/bin/vinyladm/vinyladm.c
+++ b/bin/vinyladm/vinyladm.c
@@ -91,7 +91,7 @@ cli_write(int sock, const char *s)
 {
 	int i, l;
 
-	i = strlen(s);
+	i = vstrlen(s);
 	l = write (sock, s, i);
 	if (i == l)
 		return;
@@ -185,7 +185,7 @@ pass_answer(int fd, enum pass_mode_e mode)
 	}
 
 	if (p_arg && answer != NULL) {
-		printf("%-3u %-8zu\n%s", status, strlen(answer), answer);
+		printf("%-3u %-8zu\n%s", status, vstrlen(answer), answer);
 	} else if (p_arg) {
 		printf("%-3u %-8u\n", status, 0U);
 	} else {
@@ -279,7 +279,7 @@ command_generator (const char *text, int state)
 		jv = VTAILQ_NEXT(jv, list);
 		assert (vjsn_is_string(jv2));
 		assert (!strcmp(jv2->name, "request"));
-		if (!strncmp(text, jv2->value, strlen(text)))
+		if (!strncmp(text, jv2->value, vstrlen(text)))
 			return (strdup(jv2->value));
 	}
 	vjsn_delete(&jsn_cmds);

--- a/bin/vinyladm/vinyladm.c
+++ b/bin/vinyladm/vinyladm.c
@@ -278,7 +278,7 @@ command_generator (const char *text, int state)
 		AN(jv2);
 		jv = VTAILQ_NEXT(jv, list);
 		assert (vjsn_is_string(jv2));
-		assert (!strcmp(jv2->name, "request"));
+		assert (!vstrcmp(jv2->name, "request"));
 		if (!strncmp(text, jv2->value, vstrlen(text)))
 			return (strdup(jv2->value));
 	}
@@ -467,7 +467,7 @@ main(int argc, char * const *argv)
 	char *wd;
 	int opt, sock;
 
-	if (argc == 2 && !strcmp(argv[1], "--optstring")) {
+	if (argc == 2 && !vstrcmp(argv[1], "--optstring")) {
 		printf(OPTARG "\n");
 		exit(0);
 	}
@@ -501,7 +501,7 @@ main(int argc, char * const *argv)
 			break;
 		case 'x':
 			AN(optarg);
-			if (strcmp(optarg, "workdir")) {
+			if (vstrcmp(optarg, "workdir")) {
 				fprintf(stderr, "Invalid -x argument\n");
 				usage(1);
 			}

--- a/bin/vinyld/acceptor/cache_acceptor_tcp.c
+++ b/bin/vinyld/acceptor/cache_acceptor_tcp.c
@@ -121,7 +121,7 @@ vca_tcp_sockopt_init(void)
 
 #define SET_VAL(nm, so, fld, val)					\
 	do {								\
-		if (!strcmp(#nm, so->strname)) {			\
+		if (!vstrcmp(#nm, so->strname)) {			\
 			assert(so->sz == sizeof so->arg->fld);		\
 			so->arg->fld = (val);				\
 		}							\
@@ -129,7 +129,7 @@ vca_tcp_sockopt_init(void)
 
 #define NEW_VAL(nm, so, fld, val)					\
 	do {								\
-		if (!strcmp(#nm, so->strname)) {			\
+		if (!vstrcmp(#nm, so->strname)) {			\
 			sz = sizeof tmp.fld;				\
 			assert(so->sz == sz);				\
 			tmp.fld = (val);				\

--- a/bin/vinyld/acceptor/cache_acceptor_uds.c
+++ b/bin/vinyld/acceptor/cache_acceptor_uds.c
@@ -107,7 +107,7 @@ vca_uds_sockopt_init(void)
 
 #define SET_VAL(nm, so, fld, val)					\
 	do {								\
-		if (!strcmp(#nm, so->strname)) {			\
+		if (!vstrcmp(#nm, so->strname)) {			\
 			assert(so->sz == sizeof so->arg->fld);		\
 			so->arg->fld = (val);				\
 		}							\
@@ -115,7 +115,7 @@ vca_uds_sockopt_init(void)
 
 #define NEW_VAL(nm, so, fld, val)					\
 	do {								\
-		if (!strcmp(#nm, so->strname)) {			\
+		if (!vstrcmp(#nm, so->strname)) {			\
 			sz = sizeof tmp.fld;				\
 			assert(so->sz == sz);				\
 			tmp.fld = (val);				\

--- a/bin/vinyld/acceptor/mgt_acceptor.c
+++ b/bin/vinyld/acceptor/mgt_acceptor.c
@@ -76,7 +76,7 @@ VCA_Find(const char *name)
 	VCA_Foreach(vca) {
 		CHECK_OBJ_NOTNULL(vca, ACCEPTOR_MAGIC);
 
-		if (!strcmp(vca->name, name))
+		if (!vstrcmp(vca->name, name))
 			return (vca);
 	}
 

--- a/bin/vinyld/acceptor/mgt_acceptor_tcp.c
+++ b/bin/vinyld/acceptor/mgt_acceptor_tcp.c
@@ -99,7 +99,7 @@ vca_tcp_open_cb(void *priv, const struct suckaddr *sa)
 	CAST_OBJ_NOTNULL(la, priv, LISTEN_ARG_MAGIC);
 
 	VTAILQ_FOREACH(ls, &TCP_acceptor.socks, vcalist) {
-		CHECK_OBJ_NOTNULL(ls, LISTEN_SOCK_MAGIC);
+		CHECK_OBJ(ls, LISTEN_SOCK_MAGIC);
 
 		if (!VSA_Compare(sa, ls->addr))
 			ARGV_ERR("-a arguments %s and %s have same address\n",

--- a/bin/vinyld/acceptor/mgt_acceptor_uds.c
+++ b/bin/vinyld/acceptor/mgt_acceptor_uds.c
@@ -117,7 +117,7 @@ vca_uds_open_cb(void *priv, const struct sockaddr_un *uds)
 	(void) uds;
 
 	VTAILQ_FOREACH(ls, &UDS_acceptor.socks, vcalist) {
-		CHECK_OBJ_NOTNULL(ls, LISTEN_SOCK_MAGIC);
+		CHECK_OBJ(ls, LISTEN_SOCK_MAGIC);
 
 		if (strcmp(ls->endpoint, la->endpoint) == 0)
 			ARGV_ERR("-a arguments %s and %s have same address\n",

--- a/bin/vinyld/acceptor/mgt_acceptor_uds.c
+++ b/bin/vinyld/acceptor/mgt_acceptor_uds.c
@@ -119,7 +119,7 @@ vca_uds_open_cb(void *priv, const struct sockaddr_un *uds)
 	VTAILQ_FOREACH(ls, &UDS_acceptor.socks, vcalist) {
 		CHECK_OBJ(ls, LISTEN_SOCK_MAGIC);
 
-		if (strcmp(ls->endpoint, la->endpoint) == 0)
+		if (vstrcmp(ls->endpoint, la->endpoint) == 0)
 			ARGV_ERR("-a arguments %s and %s have same address\n",
 			    ls->endpoint, la->endpoint);
 	}

--- a/bin/vinyld/cache/cache_backend_probe.c
+++ b/bin/vinyld/cache/cache_backend_probe.c
@@ -284,7 +284,7 @@ vbp_write_proxy_v1(struct vbp_target *vt, const struct vco *oper,
 	AZ(VSB_finish(&vsb));
 
 	VSB_fini(&vsb);
-	return (vbp_write(vt, oper, oper_priv, fd, buf, strlen(buf)));
+	return (vbp_write(vt, oper, oper_priv, fd, buf, vstrlen(buf)));
 }
 
 static void

--- a/bin/vinyld/cache/cache_ban.c
+++ b/bin/vinyld/cache/cache_ban.c
@@ -483,7 +483,7 @@ BAN_Time(const struct ban *b)
 	if (b == NULL)
 		return (0.0);
 
-	CHECK_OBJ_NOTNULL(b, BAN_MAGIC);
+	CHECK_OBJ(b, BAN_MAGIC);
 	return (ban_time(b->spec));
 }
 

--- a/bin/vinyld/cache/cache_ban.c
+++ b/bin/vinyld/cache/cache_ban.c
@@ -569,7 +569,7 @@ ban_evaluate(struct worker *wrk, const uint8_t *bsarg, struct objcore *oc,
 			if (arg1 == NULL) {
 				if (isnan(darg1) || darg1 != darg2)
 					return (0);
-			} else if (strcmp(arg1, bt.arg2)) {
+			} else if (vstrcmp(arg1, bt.arg2)) {
 				return (0);
 			}
 			break;
@@ -577,7 +577,7 @@ ban_evaluate(struct worker *wrk, const uint8_t *bsarg, struct objcore *oc,
 			if (arg1 == NULL) {
 				if (! isnan(darg1) && darg1 == darg2)
 					return (0);
-			} else if (!strcmp(arg1, bt.arg2)) {
+			} else if (!vstrcmp(arg1, bt.arg2)) {
 				return (0);
 			}
 			break;
@@ -748,7 +748,7 @@ ccf_ban(struct cli *cli, const char * const *av, void *priv)
 		return;
 	}
 	for (i = 3; i < narg; i += 4) {
-		if (strcmp(av[i + 2], "&&")) {
+		if (vstrcmp(av[i + 2], "&&")) {
 			VCLI_Out(cli, "Found \"%s\" expected &&", av[i + 2]);
 			VCLI_SetResult(cli, CLIS_PARAM);
 			return;
@@ -946,7 +946,7 @@ ccf_ban_list(struct cli *cli, const char * const *av, void *priv)
 	bl->refcount++;
 	Lck_Unlock(&ban_mtx);
 
-	if (av[2] != NULL && strcmp(av[2], "-j") == 0)
+	if (av[2] != NULL && vstrcmp(av[2], "-j") == 0)
 		ban_list_json(cli, av, bl);
 	else
 		ban_list(cli, bl);

--- a/bin/vinyld/cache/cache_ban_build.c
+++ b/bin/vinyld/cache/cache_ban_build.c
@@ -302,7 +302,7 @@ BAN_AddTest(struct ban_proto *bp,
 
 	VSB_putc(bp->vsb, pv->tag);
 	if (pv->flag & BANS_FLAG_HTTP) {
-		if (strlen(a1 + strlen(pv->name)) < 1)
+		if (vstrlen(a1 + vstrlen(pv->name)) < 1)
 			return (ban_error(bp,
 			    "Missing header name: \"%s\"", pv->name));
 		assert(BANS_HAS_ARG1_SPEC(pv->tag));

--- a/bin/vinyld/cache/cache_ban_build.c
+++ b/bin/vinyld/cache/cache_ban_build.c
@@ -172,7 +172,7 @@ ban_parse_http(const struct ban_proto *bp, const char *a1)
 {
 	int l;
 
-	l = strlen(a1) + 1;
+	l = vstrlen(a1) + 1;
 	assert(l <= 127);
 	VSB_putc(bp->vsb, (char)l);
 	VSB_cat(bp->vsb, a1);
@@ -231,7 +231,7 @@ ban_add_spec(struct ban_proto *bp, const struct pvar *pv, int op, const char *a3
 
 	assert(! BANS_HAS_ARG2_DOUBLE(pv->tag));
 
-	ban_add_lump(bp, a3, strlen(a3) + 1);
+	ban_add_lump(bp, a3, vstrlen(a3) + 1);
 	VSB_putc(bp->vsb, op);
 
 	if (! BANS_HAS_ARG2_SPEC(op))
@@ -290,7 +290,7 @@ BAN_AddTest(struct ban_proto *bp,
 	for (pv = pvars; pv->name != NULL; pv++) {
 		if (!(pv->flag & BANS_FLAG_HTTP) && !strcmp(a1, pv->name))
 			break;
-		if ((pv->flag & BANS_FLAG_HTTP) && !strncmp(a1, pv->name, strlen(pv->name)))
+		if ((pv->flag & BANS_FLAG_HTTP) && !strncmp(a1, pv->name, vstrlen(pv->name)))
 			break;
 	}
 
@@ -306,7 +306,7 @@ BAN_AddTest(struct ban_proto *bp,
 			return (ban_error(bp,
 			    "Missing header name: \"%s\"", pv->name));
 		assert(BANS_HAS_ARG1_SPEC(pv->tag));
-		ban_parse_http(bp, a1 + strlen(pv->name));
+		ban_parse_http(bp, a1 + vstrlen(pv->name));
 	}
 
 	op = ban_parse_oper(a2);

--- a/bin/vinyld/cache/cache_ban_build.c
+++ b/bin/vinyld/cache/cache_ban_build.c
@@ -216,7 +216,7 @@ ban_parse_oper(const char *p)
 	int i;
 
 	for (i = 0; i < BAN_OPERARRSZ; i++) {
-		if (!strcmp(p, ban_oper[i]))
+		if (!vstrcmp(p, ban_oper[i]))
 			return (BANS_OPER_OFF_ + i);
 	}
 	return (-1);
@@ -288,7 +288,7 @@ BAN_AddTest(struct ban_proto *bp,
 		return (bp->err);
 
 	for (pv = pvars; pv->name != NULL; pv++) {
-		if (!(pv->flag & BANS_FLAG_HTTP) && !strcmp(a1, pv->name))
+		if (!(pv->flag & BANS_FLAG_HTTP) && !vstrcmp(a1, pv->name))
 			break;
 		if ((pv->flag & BANS_FLAG_HTTP) && !strncmp(a1, pv->name, vstrlen(pv->name)))
 			break;

--- a/bin/vinyld/cache/cache_conn_pool.c
+++ b/bin/vinyld/cache/cache_conn_pool.c
@@ -839,7 +839,7 @@ vus_name(const struct pfd *pfd, char *addr, unsigned alen, char *pbuf,
 	 unsigned plen)
 {
 	(void) pfd;
-	assert(alen > strlen("0.0.0.0"));
+	assert(alen > vstrlen("0.0.0.0"));
 	assert(plen > 1);
 	strcpy(addr, "0.0.0.0");
 	strcpy(pbuf, "0");
@@ -984,12 +984,12 @@ VCP_Ref(const struct vrt_endpoint *vep, const char *ident, struct vsb *err)
 	AN(vsc);
 
 	VSHA256_Init(cx);
-	VSHA256_Update(cx, ident, strlen(ident) + 1); // include \0
+	VSHA256_Update(cx, ident, vstrlen(ident) + 1); // include \0
 	if (vep->uds_path != NULL) {
 		AZ(vep->ipv4);
 		AZ(vep->ipv6);
 		VSHA256_Update(cx, "UDS", 4); // include \0
-		VSHA256_Update(cx, vep->uds_path, strlen(vep->uds_path));
+		VSHA256_Update(cx, vep->uds_path, vstrlen(vep->uds_path));
 	} else {
 		assert(vep->ipv4 != NULL || vep->ipv6 != NULL);
 		if (vep->ipv4 != NULL) {

--- a/bin/vinyld/cache/cache_director.c
+++ b/bin/vinyld/cache/cache_director.c
@@ -235,7 +235,7 @@ VRT_Healthy(VRT_CTX, VCL_BACKEND d, VCL_TIME *changed)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (d == NULL)
 		return (0);
-	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+	CHECK_OBJ(d, DIRECTOR_MAGIC);
 
 	if (d->vdir->admin_health->health >= 0) {
 		if (changed != NULL)

--- a/bin/vinyld/cache/cache_esi_parse.c
+++ b/bin/vinyld/cache/cache_esi_parse.c
@@ -466,7 +466,7 @@ static void
 include_attr_onerror(struct vep_state *vep)
 {
 
-	vep->include_continue = !strcmp("continue", VSB_data(vep->attr_vsb));
+	vep->include_continue = !vstrcmp("continue", VSB_data(vep->attr_vsb));
 	VSB_destroy(&vep->attr_vsb);
 }
 
@@ -481,11 +481,11 @@ vep_do_include(struct vep_state *vep, enum dowhat what)
 	if (what == DO_ATTR) {
 		Debug("ATTR (%s) (%s)\n", vep->match_hit->match,
 			VSB_data(vep->attr_vsb));
-		if (!strcmp("src=", vep->match_hit->match)) {
+		if (!vstrcmp("src=", vep->match_hit->match)) {
 			include_attr_src(vep);
 			return;
 		}
-		if (!strcmp("onerror=", vep->match_hit->match)) {
+		if (!vstrcmp("onerror=", vep->match_hit->match)) {
 			include_attr_onerror(vep);
 			return;
 		}

--- a/bin/vinyld/cache/cache_esi_parse.c
+++ b/bin/vinyld/cache/cache_esi_parse.c
@@ -229,7 +229,7 @@ vep_match(const struct vep_state *vep, const char *b, const char *e)
 
 	AN(vep->match);
 	for (vm = vep->match; vm->match != NULL; vm++) {
-		assert(strlen(vm->match) <= sizeof (vep->tag));
+		assert(vstrlen(vm->match) <= sizeof (vep->tag));
 		r = b;
 		for (q = vm->match; *q != '\0' && r < e; q++, r++)
 			if (*q != *r)
@@ -965,7 +965,7 @@ VEP_Parse(struct vep_state *vep, const char *p, size_t l)
 			vep->match_hit = vm;
 			if (vm != NULL) {
 				if (vm->match != NULL)
-					p += strlen(vm->match);
+					p += vstrlen(vm->match);
 				vep->state = *vm->state;
 				vep->match = NULL;
 				vep->tag_i = 0;
@@ -1003,7 +1003,7 @@ VEP_Parse(struct vep_state *vep, const char *p, size_t l)
 				vep->match_hit = vm;
 				vep->state = *vm->state;
 				if (vm->match != NULL) {
-					i = strlen(vm->match);
+					i = vstrlen(vm->match);
 					if (i > vep->tag_i)
 						p += i - vep->tag_i;
 				}

--- a/bin/vinyld/cache/cache_expire.c
+++ b/bin/vinyld/cache/cache_expire.c
@@ -357,7 +357,7 @@ exp_expire(struct exp_priv *ep, vtim_real now)
 	VSLb(&ep->vsl, SLT_ExpKill, "EXP_Inspect p=%p e=%.6f f=0x%x", oc,
 	    oc->timer_when - now, oc->flags);
 
-	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+	CHECK_OBJ(oc, OBJCORE_MAGIC);
 
 	/* Ready ? */
 	if (oc->timer_when > now)

--- a/bin/vinyld/cache/cache_hash.c
+++ b/bin/vinyld/cache/cache_hash.c
@@ -219,7 +219,7 @@ HSH_AddString(struct req *req, void *ctx, const char *str)
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	AN(ctx);
 	if (str != NULL) {
-		VSHA256_Update(ctx, str, strlen(str));
+		VSHA256_Update(ctx, str, vstrlen(str));
 		VSLbs(req->vsl, SLT_Hash, TOSTRAND(str));
 	} else
 		VSHA256_Update(ctx, &str, 1);

--- a/bin/vinyld/cache/cache_http.c
+++ b/bin/vinyld/cache/cache_http.c
@@ -559,7 +559,7 @@ http_CollectHdrSep(struct http *hp, hdr_t hdr, const char *sep)
 
 	if (sep == NULL || *sep == '\0')
 		sep = ", ";
-	lsep = strlen(sep);
+	lsep = vstrlen(sep);
 
 	f = http_findhdr(hp, hdr->len - 1, hdr->str);
 	if (f == 0)
@@ -709,7 +709,7 @@ http_split(const char **src, const char *stop, const char *sep,
 static int
 http_istoken(const char **bp, const char *e, const char *token)
 {
-	int fl = strlen(token);
+	int fl = vstrlen(token);
 	const char *b;
 
 	AN(bp);
@@ -1595,7 +1595,7 @@ http_TimeHeader(struct http *to, const char *fmt, vtim_real now)
 		http_fail(to);
 		return;
 	}
-	p = WS_Alloc(to->ws, strlen(fmt) + VTIM_FORMAT_SIZE);
+	p = WS_Alloc(to->ws, vstrlen(fmt) + VTIM_FORMAT_SIZE);
 	if (p == NULL) {
 		http_fail(to);
 		VSLbs(to->vsl, SLT_LostHeader, TOSTRAND(fmt));

--- a/bin/vinyld/cache/cache_http.c
+++ b/bin/vinyld/cache/cache_http.c
@@ -1166,7 +1166,7 @@ http_ForceField(struct http *to, unsigned n, const char *t)
 	AN(t);
 
 	/* NB: method names and protocol versions are case-sensitive. */
-	if (to->hd[n].b == NULL || strcmp(to->hd[n].b, t)) {
+	if (to->hd[n].b == NULL || vstrcmp(to->hd[n].b, t)) {
 		i = (HTTP_HDR_UNSET - HTTP_HDR_METHOD);
 		i += to->logtag;
 		/* XXX: this is a dead branch */
@@ -1377,13 +1377,13 @@ HTTP_GetHdrPack(struct worker *wrk, struct objcore *oc, hdr_t hdr)
 		ptr += 4;	/* Skip nhd and status */
 
 		/* XXX: should we also have h2_hdr_eq() ? */
-		if (!strcmp(hdr->str, ":proto:"))
+		if (!vstrcmp(hdr->str, ":proto:"))
 			return (ptr);
 		ptr = strchr(ptr, '\0') + 1;
-		if (!strcmp(hdr->str, ":status:"))
+		if (!vstrcmp(hdr->str, ":status:"))
 			return (ptr);
 		ptr = strchr(ptr, '\0') + 1;
-		if (!strcmp(hdr->str, ":reason:"))
+		if (!vstrcmp(hdr->str, ":reason:"))
 			return (ptr);
 		WRONG("Unknown magic packed header");
 	}

--- a/bin/vinyld/cache/cache_lck.c
+++ b/bin/vinyld/cache/cache_lck.c
@@ -98,7 +98,7 @@ Lck_Witness_Unlock(const struct ilck *il)
 		r = q;
 	else
 		*r++ = '\0';
-	if (memcmp(r, il->w, strlen(il->w)))
+	if (memcmp(r, il->w, vstrlen(il->w)))
 		VSL(SLT_Witness, NO_VXID, "Unlock %s @ %s <%s>", il->w, r, q);
 	else
 		*r = '\0';

--- a/bin/vinyld/cache/cache_main.c
+++ b/bin/vinyld/cache/cache_main.c
@@ -143,7 +143,7 @@ thr_setname_generic(const char *name)
 	/* The Linux kernel enforces a strict limitation of 15 bytes name,
 	 * truncate the name if we would overflow it.
 	 */
-	if (strlen(name) > 15) {
+	if (vstrlen(name) > 15) {
 		bprintf(buf, "%.14s~", name);
 		name = buf;
 	}

--- a/bin/vinyld/cache/cache_panic.c
+++ b/bin/vinyld/cache/cache_panic.c
@@ -696,7 +696,7 @@ pan_ic(const char *func, const char *file, int line, const char *cond,
 
 	assert (VSB_len(pan_vsb) == 0);
 
-	AZ(pthread_setspecific(panic_key, pan_vsb));
+	PTOK(pthread_setspecific(panic_key, pan_vsb));
 
 	/*
 	 * should we trigger a SIGSEGV while handling a panic, our sigsegv

--- a/bin/vinyld/cache/cache_panic.c
+++ b/bin/vinyld/cache/cache_panic.c
@@ -263,7 +263,7 @@ pan_objcore(struct vsb *vsb, const char *typ, const struct objcore *oc)
 	VSB_printf(vsb, "stevedore = %p", oc->stobj->stevedore);
 	if (oc->stobj->stevedore != NULL) {
 		VSB_printf(vsb, " (%s", oc->stobj->stevedore->name);
-		if (strlen(oc->stobj->stevedore->ident))
+		if (vstrlen(oc->stobj->stevedore->ident))
 			VSB_printf(vsb, " %s", oc->stobj->stevedore->ident);
 		VSB_cat(vsb, ")");
 		if (oc->stobj->stevedore->panic) {

--- a/bin/vinyld/cache/cache_panic.c
+++ b/bin/vinyld/cache/cache_panic.c
@@ -806,7 +806,7 @@ ccf_panic(struct cli *cli, const char * const *av, void *priv)
 	(void)cli;
 	(void)av;
 	AZ(priv);
-	AZ(strcmp("", "You asked for it"));
+	AZ(vstrcmp("", "You asked for it"));
 	/* NOTREACHED */
 	abort();
 }

--- a/bin/vinyld/cache/cache_range.c
+++ b/bin/vinyld/cache/cache_range.c
@@ -163,7 +163,7 @@ vrg_ifrange(struct req *req)
 		if ((e[0] == 'W' && e[1] == '/'))	// rfc7232,l,547,548
 			return (0);
 		/* XXX: should we also have http_etag_cmp() ? */
-		return (strcmp(p, e) == 0);		// rfc7232,l,548,548
+		return (vstrcmp(p, e) == 0);		// rfc7232,l,548,548
 	}
 
 	/* assume date, strong check [RFC7232 2.2.2 p7] */

--- a/bin/vinyld/cache/cache_req_body.c
+++ b/bin/vinyld/cache/cache_req_body.c
@@ -159,6 +159,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc));
 		if (r > 0)
 			return (r);
+		AN(func);
 		if (vfps == VFP_END && r == 0 && (flush & OBJ_ITER_END) == 0)
 			r = func(priv, flush | OBJ_ITER_END, NULL, 0);
 		if (vfps != VFP_END) {

--- a/bin/vinyld/cache/cache_rfc2616.c
+++ b/bin/vinyld/cache/cache_rfc2616.c
@@ -266,7 +266,7 @@ rfc2616_strong_compare(const char *p, const char *e)
 	    (e[0] == 'W' && e[1] == '/'))
 		return (0);
 	/* XXX: should we also have http_etag_cmp() ? */
-	return (strcmp(p, e) == 0);
+	return (vstrcmp(p, e) == 0);
 }
 
 // rfc7232,l,550,552
@@ -278,7 +278,7 @@ rfc2616_weak_compare(const char *p, const char *e)
 	if (e[0] == 'W' && e[1] == '/')
 		e += 2;
 	/* XXX: should we also have http_etag_cmp() ? */
-	return (strcmp(p, e) == 0);
+	return (vstrcmp(p, e) == 0);
 }
 
 int

--- a/bin/vinyld/cache/cache_session.c
+++ b/bin/vinyld/cache/cache_session.c
@@ -214,7 +214,7 @@ SES_Set_String_Attr(struct sess *sp, enum sess_attr a, const char *src)
 	if (strcmp(sess_attr[a].type, "char"))
 		WRONG("wrong sess_attr: not char");
 
-	l = sz = strlen(src) + 1;
+	l = sz = vstrlen(src) + 1;
 	if (! ses_res_attr(sp, a, &q, &sz))
 		return (0);
 	assert(l == sz);

--- a/bin/vinyld/cache/cache_session.c
+++ b/bin/vinyld/cache/cache_session.c
@@ -211,7 +211,7 @@ SES_Set_String_Attr(struct sess *sp, enum sess_attr a, const char *src)
 	AN(src);
 
 	assert(a <  SA_LAST);
-	if (strcmp(sess_attr[a].type, "char"))
+	if (vstrcmp(sess_attr[a].type, "char"))
 		WRONG("wrong sess_attr: not char");
 
 	l = sz = vstrlen(src) + 1;
@@ -230,7 +230,7 @@ SES_Get_String_Attr(const struct sess *sp, enum sess_attr a)
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 
 	assert(a <  SA_LAST);
-	if (strcmp(sess_attr[a].type, "char"))
+	if (vstrcmp(sess_attr[a].type, "char"))
 		WRONG("wrong sess_attr: not char");
 
 	if (ses_get_attr(sp, a, &q) < 0)

--- a/bin/vinyld/cache/cache_shmlog.c
+++ b/bin/vinyld/cache/cache_shmlog.c
@@ -57,7 +57,7 @@ strands_len(const struct strands *s)
 	for (i = 0; i < s->n; i++) {
 		if (s->p[i] == NULL || *s->p[i] == '\0')
 			continue;
-		r += strlen(s->p[i]);
+		r += vstrlen(s->p[i]);
 	}
 
 	return (r);
@@ -82,7 +82,7 @@ strands_cat(char *buf, unsigned bufl, const struct strands *s)
 	for (i = 0; i < s->n && bufl > 0; i++) {
 		if (s->p[i] == NULL || *s->p[i] == '\0')
 			continue;
-		ll = vmin_t(unsigned, strlen(s->p[i]), bufl);
+		ll = vmin_t(unsigned, vstrlen(s->p[i]), bufl);
 		memcpy(buf, s->p[i], ll);
 		l += ll;
 		buf += ll;
@@ -306,7 +306,7 @@ VSLv(enum VSL_tag_e tag, vxid_t vxid, const char *fmt, va_list ap)
 		return;
 
 	if (strchr(fmt, '%') == NULL) {
-		vslr(tag, vxid, fmt, strlen(fmt) + 1);
+		vslr(tag, vxid, fmt, vstrlen(fmt) + 1);
 	} else {
 		n = vsnprintf(buf, mlen, fmt, ap);
 		n = vmin(n, mlen - 1);
@@ -401,7 +401,7 @@ vslb_simple(struct vsl_log *vsl, enum VSL_tag_e tag,
 	char *p;
 
 	if (length == 0)
-		length = strlen(str);
+		length = vstrlen(str);
 	length += 1; // NUL
 	p = vslb_get(vsl, tag, &length);
 	memcpy(p, str, length - 1);

--- a/bin/vinyld/cache/cache_shmlog.c
+++ b/bin/vinyld/cache/cache_shmlog.c
@@ -473,7 +473,7 @@ VSLbv(struct vsl_log *vsl, enum VSL_tag_e tag, const char *fmt, va_list ap)
 	/*
 	 * If the format is trivial, deal with it directly
 	 */
-	if (!strcmp(fmt, "%s")) {
+	if (!vstrcmp(fmt, "%s")) {
 		p1 = va_arg(ap, char *);
 		vslb_simple(vsl, tag, 0, p1);
 		return;

--- a/bin/vinyld/cache/cache_vary.c
+++ b/bin/vinyld/cache/cache_vary.c
@@ -381,7 +381,7 @@ VRY_Validate(const uint8_t *vary)
 	unsigned l, retval = 0;
 
 	while (vary[2] != 0) {
-		assert(strlen((const char*)vary + 3) == vary[2]);
+		assert(vstrlen((const char *)vary + 3) == vary[2]);
 		l = VRY_Len(vary);
 		retval += l;
 		vary += l;

--- a/bin/vinyld/cache/cache_vcl.c
+++ b/bin/vinyld/cache/cache_vcl.c
@@ -287,7 +287,7 @@ vcl_find(const char *name)
 	VTAILQ_FOREACH(vcl, &vcl_head, list) {
 		if (vcl->discard)
 			continue;
-		if (!strcmp(vcl->loaded_name, name))
+		if (!vstrcmp(vcl->loaded_name, name))
 			return (vcl);
 	}
 	return (NULL);
@@ -367,10 +367,10 @@ VCL_Update(struct vcl **vcc, struct vcl *vcl)
 				   * race */
 	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
 	if (vcl->label == NULL) {
-		AN(strcmp(vcl->state, VCL_TEMP_LABEL->name));
+		AN(vstrcmp(vcl->state, VCL_TEMP_LABEL->name));
 		*vcc = vcl;
 	} else {
-		AZ(strcmp(vcl->state, VCL_TEMP_LABEL->name));
+		AZ(vstrcmp(vcl->state, VCL_TEMP_LABEL->name));
 		*vcc = vcl->label;
 	}
 	CHECK_OBJ_NOTNULL(*vcc, VCL_MAGIC);
@@ -570,7 +570,7 @@ VCL_IterDirector(struct cli *cli, const char *pat,
 	ASSERT_VCL_ACTIVE();
 	vsb = VSB_new_auto();
 	AN(vsb);
-	if (pat == NULL || *pat == '\0' || !strcmp(pat, "*")) {
+	if (pat == NULL || *pat == '\0' || !vstrcmp(pat, "*")) {
 		// all backends in active VCL
 		VSB_printf(vsb, "%s.*", VCL_Name(vcl_active));
 		vcl = vcl_active;
@@ -1148,13 +1148,13 @@ vcl_cli_discard(struct cli *cli, const char * const *av, void *priv)
 	VSC_C_main->n_vcl_avail--;
 	vcl->discard = 1;
 	if (vcl->label != NULL) {
-		AZ(strcmp(vcl->state, VCL_TEMP_LABEL->name));
+		AZ(vstrcmp(vcl->state, VCL_TEMP_LABEL->name));
 		vcl->label->nlabels--;
 		vcl->label= NULL;
 	}
 	Lck_Unlock(&vcl_mtx);
 
-	if (!strcmp(vcl->state, VCL_TEMP_LABEL->name)) {
+	if (!vstrcmp(vcl->state, VCL_TEMP_LABEL->name)) {
 		VTAILQ_REMOVE(&vcl_head, vcl, list);
 		free(vcl->loaded_name);
 		AZ(vcl->vdire);
@@ -1220,7 +1220,7 @@ vcl_cli_show(struct cli *cli, const char * const *av, void *priv)
 	ASSERT_VCL_ACTIVE();
 	AZ(priv);
 
-	if (av[i] != NULL && !strcmp(av[i], "-v")) {
+	if (av[i] != NULL && !vstrcmp(av[i], "-v")) {
 		verbose = 1;
 		i++;
 	}

--- a/bin/vinyld/cache/cache_vcl.c
+++ b/bin/vinyld/cache/cache_vcl.c
@@ -1254,7 +1254,7 @@ vcl_cli_show(struct cli *cli, const char * const *av, void *priv)
 	if (verbose) {
 		for (u = 0; u < vcl->conf->nsrc; u++)
 			VCLI_Out(cli, "// VCL.SHOW %u %zd %s\n%s\n",
-			    u, strlen(vcl->conf->srcbody[u]),
+			    u, vstrlen(vcl->conf->srcbody[u]),
 			    vcl->conf->srcname[u],
 			    vcl->conf->srcbody[u]);
 	} else {

--- a/bin/vinyld/cache/cache_vpi.c
+++ b/bin/vinyld/cache/cache_vpi.c
@@ -119,7 +119,7 @@ vpi_ref_panic(struct vsb *vsb, unsigned n, const struct vcl *vcl)
 	}
 
 	if (src != NULL) {
-		w = strlen(src);
+		w = vstrlen(src);
 		assert(w > 0);
 		if (ref->offset >= (unsigned)w) {
 			src = NULL;

--- a/bin/vinyld/cache/cache_vrt.c
+++ b/bin/vinyld/cache/cache_vrt.c
@@ -942,7 +942,7 @@ VRT_ban_string(VRT_CTX, VCL_STRING str)
 				bp = NULL;
 			break;
 		}
-		if (strcmp(av[i], "&&")) {
+		if (vstrcmp(av[i], "&&")) {
 			err = WS_Printf(ctx->ws, "Expected && between "
 			    "conditions, found \"%s\"", av[i]);
 			if (err == NULL)
@@ -1045,7 +1045,7 @@ VRT_strcmp(const char *s1, const char *s2)
 {
 	if (s1 == NULL || s2 == NULL)
 		return (1);
-	return (strcmp(s1, s2));
+	return (vstrcmp(s1, s2));
 }
 
 void

--- a/bin/vinyld/cache/cache_vrt.c
+++ b/bin/vinyld/cache/cache_vrt.c
@@ -816,7 +816,7 @@ VRT_BACKEND_string(VCL_BACKEND d)
 {
 	if (d == NULL)
 		return (NULL);
-	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+	CHECK_OBJ(d, DIRECTOR_MAGIC);
 	return (d->vcl_name);
 }
 
@@ -825,7 +825,7 @@ VRT_PROBE_string(VCL_PROBE p)
 {
 	if (p == NULL)
 		return (NULL);
-	CHECK_OBJ_NOTNULL(p, VRT_BACKEND_PROBE_MAGIC);
+	CHECK_OBJ(p, VRT_BACKEND_PROBE_MAGIC);
 	return (p->vcl_name);
 }
 

--- a/bin/vinyld/cache/cache_vrt.c
+++ b/bin/vinyld/cache/cache_vrt.c
@@ -389,7 +389,7 @@ VRT_HashStrands32(VCL_STRANDS s)
 	for (i = 0; i < s->n; i++) {
 		p = s->p[i];
 		if (p != NULL && *p != '\0')
-			VSHA256_Update(&sha_ctx, p, strlen(p));
+			VSHA256_Update(&sha_ctx, p, vstrlen(p));
 	}
 	VSHA256_Final(sha256, &sha_ctx);
 
@@ -419,7 +419,7 @@ VRT_Strands(char *d, size_t dl, VCL_STRANDS s)
 	e = b + dl;
 	for (int i = 0; i < s->n; i++)
 		if (s->p[i] != NULL && *s->p[i] != '\0') {
-			x = strlen(s->p[i]);
+			x = vstrlen(s->p[i]);
 			if (b + x >= e)
 				return (NULL);
 			memcpy(b, s->p[i], x);
@@ -614,7 +614,7 @@ VRT_SetHdr(VRT_CTX, VCL_HEADER hs, const char *pfx, VCL_STRANDS s)
 	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
 
 	u = WS_ReserveAll(hp->ws);
-	pl = (pfx == NULL) ? 0 : strlen(pfx);
+	pl = (pfx == NULL) ? 0 : vstrlen(pfx);
 	l = hs->what->len + 1 + pl;
 	if (u <= l) {
 		WS_Release(hp->ws, 0);
@@ -1143,7 +1143,7 @@ VRT_Endpoint_Clone(const struct vrt_endpoint * const vep)
 	if (vep->ipv6)
 		sz += vsa_suckaddr_len;
 	if (vep->uds_path != NULL) {
-		uds_len = strlen(vep->uds_path) + 1;
+		uds_len = vstrlen(vep->uds_path) + 1;
 		sz += uds_len;
 	}
 	if (vep->hosthdr != NULL) {

--- a/bin/vinyld/cache/cache_vrt_filter.c
+++ b/bin/vinyld/cache/cache_vrt_filter.c
@@ -122,7 +122,7 @@ vrt_addfilter(VRT_CTX, const struct vfp *vfp, const struct vdp *vdp)
 	vp->vfp = vfp;
 	vp->vdp = vdp;
 	vp->name = name;
-	vp->nlen = strlen(name);
+	vp->nlen = vstrlen(name);
 	VTAILQ_INSERT_TAIL(hd, vp, list);
 	return (err);
 }

--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -1212,7 +1212,7 @@ VRT_l_resp_body(VRT_CTX, enum lbody_e type,
 		viov = VSCARAB_GET(scarab);
 		AN(viov);	// ObjGetSpace ensures
 		viov->iov.iov_base = TRUST_ME(str);
-		viov->iov.iov_len = strlen(str);
+		viov->iov.iov_len = vstrlen(str);
 	}
 
 	s = body;
@@ -1231,7 +1231,7 @@ VRT_l_resp_body(VRT_CTX, enum lbody_e type,
 		}
 		AN(viov);
 		viov->iov.iov_base = TRUST_ME(s->p[n]);
-		viov->iov.iov_len = strlen(s->p[n]);
+		viov->iov.iov_len = vstrlen(s->p[n]);
 	}
 }
 

--- a/bin/vinyld/cache/cache_vrt_var.c
+++ b/bin/vinyld/cache/cache_vrt_var.c
@@ -1084,7 +1084,7 @@ VRT_r_resp_is_streaming(VRT_CTX)
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
 	if (ctx->req->objcore == NULL)
 		return (0);	/* When called from vcl_synth */
-	CHECK_OBJ_NOTNULL(ctx->req->objcore, OBJCORE_MAGIC);
+	CHECK_OBJ(ctx->req->objcore, OBJCORE_MAGIC);
 	return (ctx->req->objcore->boc == NULL ? 0 : 1);
 }
 

--- a/bin/vinyld/cache/cache_vrt_vcl.c
+++ b/bin/vinyld/cache/cache_vrt_vcl.c
@@ -390,7 +390,7 @@ VRT_LookupDirector(VRT_CTX, VCL_STRING name)
 	vdire_start_iter(vdire);
 	VTAILQ_FOREACH(vdir, &vdire->directors, directors_list) {
 		dd = vdir->dir;
-		if (strcmp(dd->vcl_name, name))
+		if (vstrcmp(dd->vcl_name, name))
 			continue;
 		d = dd;
 		break;

--- a/bin/vinyld/cache/cache_vrt_vmod.c
+++ b/bin/vinyld/cache/cache_vrt_vmod.c
@@ -76,7 +76,7 @@ vmod_abi_mismatch(const struct vmod_data *d)
 {
 
 	if (d->vrt_major == 0 && d->vrt_minor == 0)
-		return (d->abi == NULL || strcmp(d->abi, VMOD_ABI_Version));
+		return (d->abi == NULL || vstrcmp(d->abi, VMOD_ABI_Version));
 
 	return (d->vrt_major != VRT_MAJOR_VERSION ||
 	    d->vrt_minor > VRT_MINOR_VERSION);
@@ -118,7 +118,7 @@ VPI_Vmod_Init(VRT_CTX, struct vmod **hdl, unsigned nbr, void *ptr, int len,
 		d = dlsym(v->hdl, buf);
 		if (d == NULL ||
 		    d->file_id == NULL ||
-		    strcmp(d->file_id, file_id)) {
+		    vstrcmp(d->file_id, file_id)) {
 			VSB_printf(ctx->msg, "Loading vmod %s from %s (%s):\n",
 			    nm, backup, path);
 			VSB_cat(ctx->msg,
@@ -130,7 +130,7 @@ VPI_Vmod_Init(VRT_CTX, struct vmod **hdl, unsigned nbr, void *ptr, int len,
 		}
 		if (vmod_abi_mismatch(d) ||
 		    d->name == NULL ||
-		    strcmp(d->name, nm) ||
+		    vstrcmp(d->name, nm) ||
 		    d->func == NULL ||
 		    d->func_len <= 0 ||
 		    d->proto != NULL ||

--- a/bin/vinyld/cache/cache_ws.c
+++ b/bin/vinyld/cache/cache_ws.c
@@ -70,7 +70,7 @@ WS_Allocated(const struct ws *ws, const void *ptr, ssize_t len)
 
 	WS_Assert(ws);
 	if (len < 0)
-		len = strlen(p) + 1;
+		len = vstrlen(p) + 1;
 	assert(!(p > ws->f && p <= ws->e));
 	return (p >= ws->s && (p + len) <= ws->f);
 }
@@ -193,7 +193,7 @@ WS_Copy(struct ws *ws, const void *str, int len)
 	assert(ws->r == NULL);
 
 	if (len == -1)
-		len = strlen(str) + 1;
+		len = vstrlen(str) + 1;
 	assert(len > 0);
 
 	bytes = PRNDUP((unsigned)len);

--- a/bin/vinyld/cache/cache_ws_emu.c
+++ b/bin/vinyld/cache/cache_ws_emu.c
@@ -134,7 +134,7 @@ WS_Allocated(const struct ws *ws, const void *ptr, ssize_t len)
 	WS_Assert(ws);
 	AN(ptr);
 	if (len < 0)
-		len = strlen(ptr) + 1;
+		len = vstrlen(ptr) + 1;
 	p = (uintptr_t)ptr;
 	we = ws_emu(ws);
 
@@ -325,7 +325,7 @@ WS_Copy(struct ws *ws, const void *str, int len)
 
 	AN(str);
 	if (len == -1)
-		len = strlen(str) + 1;
+		len = vstrlen(str) + 1;
 	assert(len > 0);
 	wa = ws_emu_alloc(ws, len);
 	WS_Assert(ws);

--- a/bin/vinyld/common/common_vsmw.c
+++ b/bin/vinyld/common/common_vsmw.c
@@ -149,7 +149,7 @@ vsmw_idx_head(const struct vsmw *vsmw, int fd)
 
 	bprintf(buf, "# %jd %jd\n", (intmax_t)vsmw->pid, (intmax_t)vsmw->birth);
 	// XXX handle ENOSPC? #2764
-	assert(write(fd, buf, strlen(buf)) == strlen(buf));
+	assert(write(fd, buf, vstrlen(buf)) == vstrlen(buf));
 }
 
 #define ASSERT_SEG_STR(x) do {			\

--- a/bin/vinyld/hpack/vhp_decode.c
+++ b/bin/vinyld/hpack/vhp_decode.c
@@ -640,7 +640,7 @@ match(const char *b, size_t l, ...)
 		m = va_arg(ap, const char *);
 		if (m == NULL)
 			break;
-		l = strlen(m);
+		l = vstrlen(m);
 		if (e - b <= l || b[l] != '\0' || strncmp(b, m, l)) {
 			printf("%.*s != %s\n", (int)(e - b), b, m);
 			r = -1;

--- a/bin/vinyld/hpack/vhp_decode.c
+++ b/bin/vinyld/hpack/vhp_decode.c
@@ -1179,7 +1179,7 @@ test_c6(unsigned mode)
 int
 main(int argc, char **argv)
 {
-	if (argc == 2 && !strcmp(argv[1], "-v"))
+	if (argc == 2 && !vstrcmp(argv[1], "-v"))
 		verbose = 1;
 	else if (argc != 1) {
 		fprintf(stderr, "Usage: %s [-v]\n", argv[0]);

--- a/bin/vinyld/hpack/vhp_table.c
+++ b/bin/vinyld/hpack/vhp_table.c
@@ -307,7 +307,7 @@ VHT_AppendName(struct vht_table *tbl, const char *buf, ssize_t len)
 		return;
 	AN(buf);
 	if (len < 0)
-		len = strlen(buf);
+		len = vstrlen(buf);
 	vht_trim(tbl, tbl->maxsize - len);
 	if (tbl->n == 0)
 		/* Max size exceeded */
@@ -325,7 +325,7 @@ VHT_AppendValue(struct vht_table *tbl, const char *buf, ssize_t len)
 		return;
 	AN(buf);
 	if (len < 0)
-		len = strlen(buf);
+		len = vstrlen(buf);
 	vht_trim(tbl, tbl->maxsize - len);
 	if (tbl->n == 0)
 		/* Max size exceeded */
@@ -519,10 +519,10 @@ vht_matchtable(struct vht_table *tbl, ...)
 
 		if (a) {
 			AN(b);
-			if (e->namelen != strlen(a) ||
+			if (e->namelen != vstrlen(a) ||
 			    strncmp(a, tbl->buf + e->offset, e->namelen))
 				r = -1;
-			if (e->valuelen != strlen(b) ||
+			if (e->valuelen != vstrlen(b) ||
 			    strncmp(b, tbl->buf + e->offset + e->namelen,
 			     e->valuelen))
 				r = -1;
@@ -571,21 +571,21 @@ test_1(void)
 
 	/* 1: ':authority' -> '' */
 	p = VHT_LookupName(NULL, 1, &l);
-	assert(l == strlen(":authority"));
-	AZ(strncmp(p, ":authority", strlen(":authority")));
+	assert(l == vstrlen(":authority"));
+	AZ(strncmp(p, ":authority", vstrlen(":authority")));
 	p = VHT_LookupValue(NULL, 1, &l);
 	AN(p);
 	AZ(l);
 
 	/* 5: ':path' -> '/index.html' */
 	p = VHT_LookupValue(NULL, 5, &l);
-	assert(l == strlen("/index.html"));
-	AZ(strncmp(p, "/index.html", strlen("/index.html")));
+	assert(l == vstrlen("/index.html"));
+	AZ(strncmp(p, "/index.html", vstrlen("/index.html")));
 
 	/* 61: 'www-authenticate' -> '' */
 	p = VHT_LookupName(NULL, 61, &l);
-	assert(l == strlen("www-authenticate"));
-	AZ(strncmp(p, "www-authenticate", strlen("www-authenticate")));
+	assert(l == vstrlen("www-authenticate"));
+	AZ(strncmp(p, "www-authenticate", vstrlen("www-authenticate")));
 	p = VHT_LookupValue(NULL, 61, &l);
 	AN(p);
 	AZ(l);
@@ -739,7 +739,7 @@ test_4(void)
 	/* New entry indexed from dynamic table, overlap eviction with
 	   overlap larger than the copy buffer size */
 	VHT_NewEntry(tbl);
-	VHT_AppendName(tbl, longname, strlen(longname));
+	VHT_AppendName(tbl, longname, vstrlen(longname));
 	AZ(vht_matchtable(tbl, longname, "", NULL));
 	AZ(VHT_NewEntry_Indexed(tbl, VHT_DYNAMIC + 0));
 	VHT_AppendValue(tbl, "2", -1);

--- a/bin/vinyld/hpack/vhp_table.c
+++ b/bin/vinyld/hpack/vhp_table.c
@@ -804,7 +804,7 @@ int
 main(int argc, char **argv)
 {
 
-	if (argc == 2 && !strcmp(argv[1], "-v"))
+	if (argc == 2 && !vstrcmp(argv[1], "-v"))
 		verbose = 1;
 	else if (argc != 1) {
 		fprintf(stderr, "Usage: %s [-v]\n", argv[0]);

--- a/bin/vinyld/hpack/vhp_table.c
+++ b/bin/vinyld/hpack/vhp_table.c
@@ -405,7 +405,7 @@ VHT_LookupName(const struct vht_table *tbl, unsigned idx, size_t *plen)
 
 	if (tbl == NULL)
 		return (NULL);
-	CHECK_OBJ_NOTNULL(tbl, VHT_TABLE_MAGIC);
+	CHECK_OBJ(tbl, VHT_TABLE_MAGIC);
 
 	idx -= VHT_STATIC_MAX + 1;
 	if (idx >= tbl->n)
@@ -436,7 +436,7 @@ VHT_LookupValue(const struct vht_table *tbl, unsigned idx, size_t *plen)
 
 	if (tbl == NULL)
 		return (NULL);
-	CHECK_OBJ_NOTNULL(tbl, VHT_TABLE_MAGIC);
+	CHECK_OBJ(tbl, VHT_TABLE_MAGIC);
 
 	idx -= VHT_STATIC_MAX + 1;
 	if (idx >= tbl->n)

--- a/bin/vinyld/http1/cache_http1_fetch.c
+++ b/bin/vinyld/http1/cache_http1_fetch.c
@@ -117,7 +117,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 			(void) V1L_Close(&v1l, &bytes);
 		if (VALID_OBJ(vdc, VDP_CTX_MAGIC))
 			(void) VDP_Close(vdc, NULL, NULL);
-		VSLb(bo->vsl, SLT_FetchError, "%s", err);
+		VSLbs(bo->vsl, SLT_FetchError, TOSTRAND(err));
 		VSLb_ts_busyobj(bo, "Bereq", W_TIM_real(wrk));
 		htc->doclose = SC_OVERLOAD;
 		return (-1);

--- a/bin/vinyld/http1/cache_http1_fsm.c
+++ b/bin/vinyld/http1/cache_http1_fsm.c
@@ -207,7 +207,7 @@ http1_minimal_response(struct req *req, uint16_t status)
 	reason = http_Status2Reason(status, NULL);
 
 	bprintf(buf, "HTTP/1.1 %03d %s\r\n\r\n", status, reason);
-	l = strlen(buf);
+	l = vstrlen(buf);
 
 	VSLb(req->vsl, SLT_RespProtocol, "HTTP/1.1");
 	VSLb(req->vsl, SLT_RespStatus, "%03d", status);

--- a/bin/vinyld/http1/cache_http1_line.c
+++ b/bin/vinyld/http1/cache_http1_line.c
@@ -217,7 +217,7 @@ V1L_Flush(struct v1l *v1l)
 		if (v1l->ciov < v1l->siov && v1l->cliov > 0) {
 			/* Add chunk head & tail */
 			bprintf(cbuf, "00%zx\r\n", v1l->cliov);
-			sz = strlen(cbuf);
+			sz = vstrlen(cbuf);
 			v1l->iov[v1l->ciov].iov_base = cbuf;
 			v1l->iov[v1l->ciov].iov_len = sz;
 			v1l->liov += sz;
@@ -304,7 +304,7 @@ V1L_Write(struct v1l *v1l, const void *ptr, ssize_t alen)
 	if (alen > 0)
 		len = (size_t)alen;
 	else if (alen == -1)
-		len = strlen(ptr);
+		len = vstrlen(ptr);
 	else
 		WRONG("alen");
 

--- a/bin/vinyld/http2/cache_http2_session.c
+++ b/bin/vinyld/http2/cache_http2_session.c
@@ -298,9 +298,9 @@ h2_ou_session(struct worker *wrk, struct h2_sess *h2,
 	}
 
 	sz = h2->htc->oper->write(h2->htc->oper_priv, h2->sess->fd,
-	    h2_resp_101, strlen(h2_resp_101));
+	    h2_resp_101, vstrlen(h2_resp_101));
 	VCO_Assert(h2->htc->oper, sz);
-	if (sz != strlen(h2_resp_101)) {
+	if (sz != vstrlen(h2_resp_101)) {
 		VSLb(h2->vsl, SLT_Debug, "H2: Upgrade: Error writing 101"
 		    " response: %s\n", VAS_errtxt(errno));
 		h2_ou_rel_req(wrk, &req);

--- a/bin/vinyld/mgt/mgt.h
+++ b/bin/vinyld/mgt/mgt.h
@@ -69,7 +69,7 @@ extern int		exit_status;
 static inline const char *
 keyval(const char *p, const char *name)
 {
-	size_t l = strlen(name);
+	size_t l = vstrlen(name);
 	if (strncmp(p, name, l))
 		return (NULL);
 	return (p + l);

--- a/bin/vinyld/mgt/mgt_child.c
+++ b/bin/vinyld/mgt/mgt_child.c
@@ -163,7 +163,7 @@ mch_cli_panic_clear(struct cli *cli, const char * const *av, void *priv)
 {
 	(void)priv;
 
-	if (av[2] != NULL && strcmp(av[2], "-z")) {
+	if (av[2] != NULL && vstrcmp(av[2], "-z")) {
 		VCLI_SetResult(cli, CLIS_PARAM);
 		VCLI_Out(cli, "Unknown parameter \"%s\".", av[2]);
 		return;

--- a/bin/vinyld/mgt/mgt_cli.c
+++ b/bin/vinyld/mgt/mgt_cli.c
@@ -110,7 +110,7 @@ mcf_panic(struct cli *cli, const char * const *av, void *priv)
 	(void)av;
 	(void)priv;
 	v_gcov_flush();
-	AZ(strcmp("", "You asked for it"));
+	AZ(vstrcmp("", "You asked for it"));
 	/* NOTREACHED */
 	abort();
 }
@@ -720,7 +720,7 @@ cli_cmp(const void *a, const void *b)
 	struct cli_cmd_desc * const * const aa = a;
 	struct cli_cmd_desc * const * const bb = b;
 
-	return (strcmp((*aa)->request, (*bb)->request));
+	return (vstrcmp((*aa)->request, (*bb)->request));
 }
 
 void

--- a/bin/vinyld/mgt/mgt_cli.c
+++ b/bin/vinyld/mgt/mgt_cli.c
@@ -168,7 +168,7 @@ mcf_askchild(struct cli *cli, const char * const *av, void *priv)
 
 	VSB_clear(cli_buf);
 	for (i = 1; av[i] != NULL; i++) {
-		VSB_quote(cli_buf, av[i], strlen(av[i]), 0);
+		VSB_quote(cli_buf, av[i], vstrlen(av[i]), 0);
 		VSB_putc(cli_buf, ' ');
 	}
 	VSB_putc(cli_buf, '\n');
@@ -517,7 +517,7 @@ mgt_cli_secret(const char *S_arg)
 	char buf[BUFSIZ];
 
 	/* Save in shmem */
-	mgt_SHM_static_alloc(S_arg, strlen(S_arg) + 1L, "Arg", "-S");
+	mgt_SHM_static_alloc(S_arg, vstrlen(S_arg) + 1L, "Arg", "-S");
 
 	VJ_master(JAIL_MASTER_FILE);
 	fd = open(S_arg, O_RDONLY);
@@ -745,7 +745,7 @@ mgt_DumpRstCli(void)
 			fputc(*p == '.' ? '_' : *p, stdout);
 		printf(":\n\n");
 		printf("%s\n", cp->syntax);
-		for (j = 0; j < strlen(cp->syntax); j++)
+		for (j = 0; j < vstrlen(cp->syntax); j++)
 			printf("~");
 		printf("\n");
 		printf("  %s\n", cp->help);

--- a/bin/vinyld/mgt/mgt_jail_linux.c
+++ b/bin/vinyld/mgt/mgt_jail_linux.c
@@ -50,14 +50,14 @@ vjl_set_thp(const char *arg, struct vsb *vsb)
 {
 	int r, val, must;
 
-	if (!strcmp(arg, "ignore"))
+	if (!vstrcmp(arg, "ignore"))
 		return (0);
 	must = 1;
-	if (!strcmp(arg, "enable"))
+	if (!vstrcmp(arg, "enable"))
 		val = 0;
-	else if (!strcmp(arg, "disable"))
+	else if (!vstrcmp(arg, "disable"))
 		val = 1;
-	else if (!strcmp(arg, "try-disable")) {
+	else if (!vstrcmp(arg, "try-disable")) {
 		arg = "disable";
 		val = 1;
 		must = 0;

--- a/bin/vinyld/mgt/mgt_jail_linux.c
+++ b/bin/vinyld/mgt/mgt_jail_linux.c
@@ -174,8 +174,8 @@ vjl_make_workdir(const char *dname, const char *what, struct vsb *vsb)
 		return (1);
 	}
 	if (info.f_type != TMPFS_MAGIC) {
-		VSB_printf(vsb, "Working directory not mounted on"
-		    " tmpfs partition\n");
+		VSB_cat(vsb, "Working directory not mounted on"
+			" tmpfs partition\n");
 	}
 	vjl_master(JAIL_MASTER_LOW);
 	return (0);

--- a/bin/vinyld/mgt/mgt_main.c
+++ b/bin/vinyld/mgt/mgt_main.c
@@ -976,7 +976,7 @@ main(int argc, char * const *argv)
 
 	mgt_SHM_Init();
 
-	mgt_SHM_static_alloc(i_arg, strlen(i_arg) + 1L, "Arg", "-i");
+	mgt_SHM_static_alloc(i_arg, vstrlen(i_arg) + 1L, "Arg", "-i");
 	VSC_C_mgt = VSC_mgt_New(NULL, NULL, "");
 
 	VTAILQ_FOREACH(alp, &arglist, list) {

--- a/bin/vinyld/mgt/mgt_main.c
+++ b/bin/vinyld/mgt/mgt_main.c
@@ -241,7 +241,7 @@ arg_list_count(const char *arg)
 	struct arg_list *alp;
 
 	VTAILQ_FOREACH(alp, &arglist, list) {
-		if (!strcmp(alp->arg, arg))
+		if (!vstrcmp(alp->arg, arg))
 			retval++;
 	}
 	return (retval);
@@ -382,19 +382,19 @@ mgt_initialize(struct cli *cli)
 static void
 mgt_x_arg(const char *x_arg)
 {
-	if (!strcmp(x_arg, "parameter"))
+	if (!vstrcmp(x_arg, "parameter"))
 		MCF_DumpRstParam();
-	else if (!strcmp(x_arg, "parameter-json"))
+	else if (!vstrcmp(x_arg, "parameter-json"))
 		MCF_DumpJsonParam();
-	else if (!strcmp(x_arg, "vsl"))
+	else if (!vstrcmp(x_arg, "vsl"))
 		mgt_DumpRstVsl();
-	else if (!strcmp(x_arg, "cli"))
+	else if (!vstrcmp(x_arg, "cli"))
 		mgt_DumpRstCli();
-	else if (!strcmp(x_arg, "builtin"))
+	else if (!vstrcmp(x_arg, "builtin"))
 		mgt_DumpBuiltin();
-	else if (!strcmp(x_arg, "optstring"))
+	else if (!vstrcmp(x_arg, "optstring"))
 		(void)printf("%s\n", opt_spec);
-	else if (!strcmp(x_arg, "options"))
+	else if (!vstrcmp(x_arg, "options"))
 		mgt_DumpOptions();
 	else
 		ARGV_ERR("Invalid -x argument\n");
@@ -652,7 +652,7 @@ main(int argc, char * const *argv)
 	int first_arg = 1;
 	struct vsb *vsb;
 
-	if (argc == 2 && !strcmp(argv[1], "--optstring")) {
+	if (argc == 2 && !vstrcmp(argv[1], "--optstring")) {
 		printf("%s\n", opt_spec);
 		exit(0);
 	}
@@ -865,7 +865,7 @@ main(int argc, char * const *argv)
 		n_arg = p;
 	}
 
-	if (S_arg != NULL && !strcmp(S_arg, "none")) {
+	if (S_arg != NULL && !vstrcmp(S_arg, "none")) {
 		fprintf(stderr,
 		    "Warning: CLI authentication disabled.\n");
 	} else if (S_arg != NULL) {
@@ -950,14 +950,14 @@ main(int argc, char * const *argv)
 
 	u = 0;
 	VTAILQ_FOREACH(alp, &arglist, list) {
-		if (!strcmp(alp->arg, "f") && alp->priv != NULL)
+		if (!vstrcmp(alp->arg, "f") && alp->priv != NULL)
 			u |= mgt_process_f_arg(cli, C_flag, &alp->priv);
 	}
 	if (C_flag)
 		exit(u);
 
 	VTAILQ_FOREACH(alp, &arglist, list) {
-		if (!strcmp(alp->arg, "P"))
+		if (!vstrcmp(alp->arg, "P"))
 			alp->priv = create_pid_file(&pid, "%s", alp->val);
 	}
 
@@ -980,11 +980,11 @@ main(int argc, char * const *argv)
 	VSC_C_mgt = VSC_mgt_New(NULL, NULL, "");
 
 	VTAILQ_FOREACH(alp, &arglist, list) {
-		if (!strcmp(alp->arg, "M"))
+		if (!vstrcmp(alp->arg, "M"))
 			mgt_cli_master(alp->val);
-		else if (!strcmp(alp->arg, "T") && strcmp(alp->val, "none"))
+		else if (!vstrcmp(alp->arg, "T") && vstrcmp(alp->val, "none"))
 			mgt_cli_telnet(alp->val);
-		else if (!strcmp(alp->arg, "P"))
+		else if (!vstrcmp(alp->arg, "P"))
 			VPF_Write(alp->priv);
 	}
 
@@ -1000,7 +1000,7 @@ main(int argc, char * const *argv)
 	if (d_flag)
 		mgt_cli_setup(0, 1, 1, "debug", mgt_stdin_close, NULL);
 
-	if (strcmp(S_arg, "none"))
+	if (vstrcmp(S_arg, "none"))
 		mgt_cli_secret(S_arg);
 
 	memset(&sac, 0, sizeof sac);
@@ -1081,7 +1081,7 @@ main(int argc, char * const *argv)
 	(void)rmdir("vext_cache");
 	VJ_master(JAIL_MASTER_LOW);
 	VTAILQ_FOREACH(alp, &arglist, list) {
-		if (!strcmp(alp->arg, "P"))
+		if (!vstrcmp(alp->arg, "P"))
 			VPF_Remove(alp->priv);
 	}
 	exit(exit_status);

--- a/bin/vinyld/mgt/mgt_param.c
+++ b/bin/vinyld/mgt/mgt_param.c
@@ -128,7 +128,7 @@ mcf_findpar(const char *name)
 
 	AN(name);
 	VTAILQ_FOREACH(pl, &phead, list)
-		if (!strcmp(pl->spec->name, name))
+		if (!vstrcmp(pl->spec->name, name))
 			return (pl->spec);
 	return (NULL);
 }
@@ -143,7 +143,7 @@ mcf_addpar(struct parspec *ps)
 	AN(pl);
 	pl->spec = ps;
 	VTAILQ_FOREACH(pl2, &phead, list) {
-		i = strcmp(pl2->spec->name, pl->spec->name);
+		i = vstrcmp(pl2->spec->name, pl->spec->name);
 		if (i == 0) {
 			fprintf(stderr, "Duplicate param: %s\n", ps->name);
 			exit(4);
@@ -747,7 +747,7 @@ mcf_wash_param(struct cli *cli, struct parspec *pp, enum mcf_which_e which,
 	err = pp->func(vsb, pp, NULL);
 	AZ(err);
 	AZ(VSB_finish(vsb));
-	if (strcmp(val, VSB_data(vsb)))
+	if (vstrcmp(val, VSB_data(vsb)))
 		mcf_dyn_vsb(which, pp, vsb);
 }
 

--- a/bin/vinyld/mgt/mgt_param.c
+++ b/bin/vinyld/mgt/mgt_param.c
@@ -680,7 +680,7 @@ mcf_init_params(void)
 			exit(4);
 		}
 		mcf_addpar(pp);
-		margin2 = vmax_t(int, margin2, strlen(pp->name) + 1);
+		margin2 = vmax_t(int, margin2, vstrlen(pp->name) + 1);
 	}
 }
 
@@ -879,7 +879,7 @@ MCF_DumpRstParam(void)
 		    continue;
 		printf(".. _ref_param_%s:\n\n", pp->name);
 		printf("%s\n", pp->name);
-		for (z = 0; z < strlen(pp->name); z++)
+		for (z = 0; z < vstrlen(pp->name); z++)
 			printf("~");
 		printf("\n");
 

--- a/bin/vinyld/mgt/mgt_param_tweak.c
+++ b/bin/vinyld/mgt/mgt_param_tweak.c
@@ -859,7 +859,7 @@ tweak_vcc_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
 		if (val < 0)
 			return (-1);
 		bprintf(buf, "%c%s", val ? '+' : '-',
-		    par->name + strlen("vcc_"));
+		    par->name + vstrlen("vcc_"));
 		return (tweak_vcc_feature(vsb, orig, buf));
 	}
 	return (tweak_generic_bits(vsb, par, arg, mgt_param.vcc_feature_bits,

--- a/bin/vinyld/mgt/mgt_param_tweak.c
+++ b/bin/vinyld/mgt/mgt_param_tweak.c
@@ -140,7 +140,7 @@ tweak_timeout(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile double *dest = par->priv;
 
-	if (arg != NULL && !strcmp(arg, "never")) {
+	if (arg != NULL && !vstrcmp(arg, "never")) {
 		*dest = INFINITY;
 		return (0);
 	}
@@ -299,7 +299,7 @@ tweak_uint_orzero(struct vsb *vsb, const struct parspec *par, const char *arg)
 	volatile unsigned *dest;
 
 	dest = par->priv;
-	if (arg != NULL && arg != JSON_FMT && ! strcmp(arg, "0")) {
+	if (arg != NULL && arg != JSON_FMT && ! vstrcmp(arg, "0")) {
 		VSB_cat(vsb, "0");
 		*dest = 0;
 		return (0);
@@ -586,8 +586,8 @@ tweak_storage(struct vsb *vsb, const struct parspec *par, const char *arg)
 	if (arg == NULL || arg == JSON_FMT)
 		return (tweak_string(vsb, par, arg));
 
-	if (!strcmp(arg, "Transient") ||
-	    !strcmp(arg, "Synth")) {
+	if (!vstrcmp(arg, "Transient") ||
+	    !vstrcmp(arg, "Synth")) {
 		/* Always allow setting the special names
 		 *
 		 * There will always be a stevedore with each of these names,
@@ -598,7 +598,7 @@ tweak_storage(struct vsb *vsb, const struct parspec *par, const char *arg)
 		 * stevedore */
 		STV_Foreach(stv) {
 			CHECK_OBJ_NOTNULL(stv, STEVEDORE_MAGIC);
-			if (!strcmp(stv->ident, arg))
+			if (!vstrcmp(stv->ident, arg))
 				break;
 		}
 		if (stv == NULL) {
@@ -677,19 +677,19 @@ bit_tweak(struct vsb *vsb, uint8_t *p, unsigned l, const char *arg,
 	}
 	for (i = 1; av[i] != NULL; i++) {
 		s = av[i];
-		if (sign == '+' && !strcmp(s, "none")) {
+		if (sign == '+' && !vstrcmp(s, "none")) {
 			bit_clear(p, l);
 			continue;
 		}
-		if (sign == '+' && !strcmp(s, "all")) {
+		if (sign == '+' && !vstrcmp(s, "all")) {
 			bit_set(p, l);
 			continue;
 		}
-		if (sign == '-' && !strcmp(s, "all")) {
+		if (sign == '-' && !vstrcmp(s, "all")) {
 			bit_clear(p, l);
 			continue;
 		}
-		if (sign == '-' && !strcmp(s, "none")) {
+		if (sign == '-' && !vstrcmp(s, "none")) {
 			bit_set(p, l);
 			continue;
 		}
@@ -728,7 +728,7 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 {
 	unsigned j, all;
 
-	if (arg != NULL && !strcmp(arg, "default")) {
+	if (arg != NULL && !vstrcmp(arg, "default")) {
 		/* XXX: deprecated in favor of param.reset */
 		return (tweak_generic_bits(vsb, par, par->def, p, l, tags,
 		    desc, sign));
@@ -853,7 +853,7 @@ tweak_vcc_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
 	int val;
 
 	if (arg != NULL && arg != JSON_FMT &&
-	    strcmp(par->name, "vcc_feature")) {
+	    vstrcmp(par->name, "vcc_feature")) {
 		orig = TRUST_ME(par->priv);
 		val = parse_boolean(vsb, arg);
 		if (val < 0)

--- a/bin/vinyld/mgt/mgt_symtab.c
+++ b/bin/vinyld/mgt/mgt_symtab.c
@@ -136,7 +136,7 @@ mgt_vcl_import_vmod(struct vclprog *vp, const struct vjsn_val *vv)
 	v_dst = mgt_vcl_symtab_val(vv, "dst");
 
 	VTAILQ_FOREACH(vf, &vmodhead, list)
-		if (!strcmp(vf->fname, v_dst))
+		if (!vstrcmp(vf->fname, v_dst))
 			break;
 	if (vf == NULL) {
 		ALLOC_OBJ(vf, VMODFILE_MAGIC);
@@ -177,12 +177,12 @@ mgt_vcl_symtab(struct vclprog *vp, const char *input)
 		if (v2 == NULL)
 			continue;
 		assert(vjsn_is_string(v2));
-		if (strcmp(v2->value, "import"))
+		if (vstrcmp(v2->value, "import"))
 			continue;
 		typ = mgt_vcl_symtab_val(v1, "type");
-		if (!strcmp(typ, "$VMOD"))
+		if (!vstrcmp(typ, "$VMOD"))
 			mgt_vcl_import_vmod(vp, v1);
-		else if (!strcmp(typ, "$VCL"))
+		else if (!vstrcmp(typ, "$VCL"))
 			mgt_vcl_import_vcl(vp, v1);
 		else
 			WRONG("Bad symtab import entry");

--- a/bin/vinyld/mgt/mgt_util.c
+++ b/bin/vinyld/mgt/mgt_util.c
@@ -71,7 +71,7 @@ void
 mgt_ProcTitle(const char *comp)
 {
 #ifdef HAVE_SETPROCTITLE
-	if (strcmp(heritage.identity, "varnishd"))
+	if (vstrcmp(heritage.identity, "varnishd"))
 		setproctitle("Varnish-%s -i %s", comp, heritage.identity);
 	else
 		setproctitle("Varnish-%s", comp);
@@ -196,7 +196,7 @@ MGT_Pick(const struct choice *cp, const char *which, const char *kind)
 {
 
 	for (; cp->name != NULL; cp++) {
-		if (!strcmp(cp->name, which))
+		if (!vstrcmp(cp->name, which))
 			return (cp->ptr);
 	}
 	ARGV_ERR("Unknown %s method \"%s\"\n", kind, which);

--- a/bin/vinyld/mgt/mgt_util.c
+++ b/bin/vinyld/mgt/mgt_util.c
@@ -90,7 +90,7 @@ mgt_sltm(const char *tag, const char *sdesc, const char *ldesc)
 	assert(sdesc != NULL && ldesc != NULL);
 	assert(*sdesc != '\0' || *ldesc != '\0');
 	printf("\n%s\n", tag);
-	i = strlen(tag);
+	i = vstrlen(tag);
 	printf("%*.*s\n\n", i, i, "------------------------------------");
 	if (*ldesc != '\0')
 		printf("%s\n", ldesc);

--- a/bin/vinyld/mgt/mgt_vcl.c
+++ b/bin/vinyld/mgt/mgt_vcl.c
@@ -83,7 +83,7 @@ mcf_vcl_parse_state(struct cli *cli, const char *s)
 {
 	if (s != NULL) {
 #define VCL_STATE(sym, str)				\
-		if (!strcmp(s, str))			\
+		if (!vstrcmp(s, str))			\
 			return (VCL_STATE_ ## sym);
 #include "tbl/vcl_states.h"
 	}
@@ -98,7 +98,7 @@ mcf_vcl_byname(const char *name)
 	struct vclprog *vp;
 
 	VTAILQ_FOREACH(vp, &vclhead, list)
-		if (!strcmp(name, vp->name))
+		if (!vstrcmp(name, vp->name))
 			return (vp);
 	return (NULL);
 }

--- a/bin/vinyld/mgt/mgt_vcl.c
+++ b/bin/vinyld/mgt/mgt_vcl.c
@@ -292,7 +292,7 @@ mgt_has_vcl(void)
 		return ("No VCL loaded");
 	if (mgt_vcl_active == NULL)
 		return ("No active VCL");
-	CHECK_OBJ_NOTNULL(mgt_vcl_active, VCLPROG_MAGIC);
+	CHECK_OBJ(mgt_vcl_active, VCLPROG_MAGIC);
 	AN(mgt_vcl_active->warm);
 	return (NULL);
 }

--- a/bin/vinyld/proxy/cache_proxy_proto.c
+++ b/bin/vinyld/proxy/cache_proxy_proto.c
@@ -112,9 +112,9 @@ vpx_proto1(const struct worker *wrk, const struct req *req)
 		return (-1);
 	}
 
-	if (!strcmp(fld[0], "TCP4"))
+	if (!vstrcmp(fld[0], "TCP4"))
 		pfam = PF_INET;
-	else if (!strcmp(fld[0], "TCP6"))
+	else if (!vstrcmp(fld[0], "TCP6"))
 		pfam = PF_INET6;
 	else {
 		VSL(SLT_ProxyGarbage, req->sp->vxid,

--- a/bin/vinyld/proxy/cache_proxy_proto.c
+++ b/bin/vinyld/proxy/cache_proxy_proto.c
@@ -666,7 +666,7 @@ vpx_format_proxy_v2(struct vsb *vsb, int proto,
 	AN(sas);
 
 	if (authority != NULL && *authority != '\0') {
-		l_authority = strlen(authority);
+		l_authority = vstrlen(authority);
 		/* 3 bytes in the TLV before the authority string */
 		assert(3 + l_authority <= UINT16_MAX);
 		l_tlv = 3 + l_authority;

--- a/bin/vinyld/storage/mgt_stevedore.c
+++ b/bin/vinyld/storage/mgt_stevedore.c
@@ -226,7 +226,7 @@ STV_Config(const char *spec)
 	}
 
 	VTAILQ_FOREACH(stv, &pre_stevedores, list)
-		if (!strcmp(stv->ident, ident))
+		if (!vstrcmp(stv->ident, ident))
 			ARGV_ERR("(-s %s) '%s' is already defined\n",
 			    spec, ident);
 
@@ -249,9 +249,9 @@ STV_Config_Final(void)
 
 	VCLS_AddFunc(mgt_cls, cli_stv);
 	STV_Foreach(stv) {
-		if (!strcmp(stv->ident, TRANSIENT_STORAGE))
+		if (!vstrcmp(stv->ident, TRANSIENT_STORAGE))
 			have_transient = 1;
-		else if (!strcmp(stv->ident, SYNTH_STORAGE))
+		else if (!vstrcmp(stv->ident, SYNTH_STORAGE))
 			have_synth = 1;
 	}
 
@@ -288,7 +288,7 @@ STV_Init(void)
 			continue;
 
 		VTAILQ_FOREACH(stv2, &proto_stevedores, list)
-			if (!strcmp(stv2->ident, av[1]))
+			if (!vstrcmp(stv2->ident, av[1]))
 				break;
 		if (stv2 == NULL)
 			ARGV_ERR("Unknown stevedore method \"%s\"\n", av[1]);
@@ -310,10 +310,10 @@ STV_Init(void)
 		AN(stv->allocobj);
 		AN(stv->methods);
 
-		if (!strcmp(stv->ident, TRANSIENT_STORAGE)) {
+		if (!vstrcmp(stv->ident, TRANSIENT_STORAGE)) {
 			AZ(stv_transient);
 			stv_transient = stv;
-		} else if (!strcmp(stv->ident, SYNTH_STORAGE)) {
+		} else if (!vstrcmp(stv->ident, SYNTH_STORAGE)) {
 			AZ(stv_synth);
 			stv_synth = stv;
 		} else

--- a/bin/vinyld/storage/stevedore.c
+++ b/bin/vinyld/storage/stevedore.c
@@ -288,7 +288,7 @@ VRT_STEVEDORE_string(VCL_STEVEDORE s)
 {
 	if (s == NULL)
 		return (NULL);
-	CHECK_OBJ_NOTNULL(s, STEVEDORE_MAGIC);
+	CHECK_OBJ(s, STEVEDORE_MAGIC);
 	return (s->vclname);
 }
 
@@ -306,7 +306,7 @@ VRT_stevedore_##nm(VCL_STEVEDORE stv)			\
 		return (0);				\
 	if (stv->var_##nm == NULL)			\
 		return (dval);				\
-	CHECK_OBJ_NOTNULL(stv, STEVEDORE_MAGIC);	\
+	CHECK_OBJ(stv, STEVEDORE_MAGIC);		\
 	return (stv->var_##nm(stv));			\
 }
 #include "tbl/vrt_stv_var.h"

--- a/bin/vinyld/storage/stevedore.c
+++ b/bin/vinyld/storage/stevedore.c
@@ -192,7 +192,7 @@ STV_open(void)
 		AN(stv->vclname);
 		if (stv->open != NULL)
 			stv->open(stv);
-		if (!strcmp(stv->ident, mgt_stv_h2_rxbuf))
+		if (!vstrcmp(stv->ident, mgt_stv_h2_rxbuf))
 			stv_h2_rxbuf = stv;
 	}
 	AN(stv_h2_rxbuf);
@@ -278,7 +278,7 @@ stv_find(const char *nm)
 	struct stevedore *stv;
 
 	STV_Foreach(stv)
-		if (!strcmp(stv->ident, nm))
+		if (!vstrcmp(stv->ident, nm))
 			return (stv);
 	return (NULL);
 }

--- a/bin/vinyld/storage/stevedore.c
+++ b/bin/vinyld/storage/stevedore.c
@@ -304,9 +304,9 @@ VRT_stevedore_##nm(VCL_STEVEDORE stv)			\
 {							\
 	if (stv == NULL)				\
 		return (0);				\
+	CHECK_OBJ(stv, STEVEDORE_MAGIC);		\
 	if (stv->var_##nm == NULL)			\
 		return (dval);				\
-	CHECK_OBJ(stv, STEVEDORE_MAGIC);		\
 	return (stv->var_##nm(stv));			\
 }
 #include "tbl/vrt_stv_var.h"

--- a/bin/vinyld/storage/storage_debug.c
+++ b/bin/vinyld/storage/storage_debug.c
@@ -129,8 +129,8 @@ smd_full_allocobj(struct worker *wrk, const struct stevedore *stv,
 }
 
 #define dur_arg(a, s, d)					\
-	(! strncmp((a), (s), strlen(s))				\
-	 && (d = VNUM_duration(a + strlen(s))) != nan(""))
+	(! strncmp((a), (s), vstrlen(s))				\
+	 && (d = VNUM_duration(a + vstrlen(s))) != nan(""))
 
 static int
 bytes_arg(char *a, const char *s, ssize_t *sz)
@@ -139,9 +139,9 @@ bytes_arg(char *a, const char *s, ssize_t *sz)
 	uintmax_t bytes;
 
 	AN(sz);
-	if (strncmp(a, s, strlen(s)))
+	if (strncmp(a, s, vstrlen(s)))
 		return (0);
-	a += strlen(s);
+	a += vstrlen(s);
 	err = VNUM_2bytes(a, &bytes, 0);
 	if (err != NULL)
 		ARGV_ERR("%s\n", err);

--- a/bin/vinyld/storage/storage_debug.c
+++ b/bin/vinyld/storage/storage_debug.c
@@ -194,7 +194,7 @@ smd_init(struct stevedore *parent, int aac, char * const *aav)
 	for (i = 0; i < aac; i++) {
 		a = aav[i];
 		if (a != NULL) {
-			if (! strcmp(a, "full")) {
+			if (! vstrcmp(a, "full")) {
 				if (getspace != NULL) {
 					ARGV_ERR("-s%s conflicting options\n",
 					    smd_stevedore.name);
@@ -204,7 +204,7 @@ smd_init(struct stevedore *parent, int aac, char * const *aav)
 				allocobj = smd_full_allocobj;
 				continue;
 			}
-			if (! strcmp(a, "lessspace")) {
+			if (! vstrcmp(a, "lessspace")) {
 				if (getspace != NULL) {
 					ARGV_ERR("-s%s conflicting options\n",
 					    smd_stevedore.name);

--- a/bin/vinyld/storage/storage_file.c
+++ b/bin/vinyld/storage/storage_file.c
@@ -460,7 +460,7 @@ smf_alloc(const struct stevedore *st, size_t sz)
 		Lck_Unlock(&sc->mtx);
 		return (NULL);
 	}
-	CHECK_OBJ_NOTNULL(smf, SMF_MAGIC);
+	CHECK_OBJ(smf, SMF_MAGIC);
 	sc->stats->g_alloc++;
 	sc->stats->c_bytes += smf->size;
 	sc->stats->g_bytes += smf->size;

--- a/bin/vinyld/storage/storage_file.c
+++ b/bin/vinyld/storage/storage_file.c
@@ -141,11 +141,11 @@ smf_init(struct stevedore *parent, int ac, char * const *av)
 			ARGV_ERR("(-sfile) granularity \"%s\": %s\n", av[2], r);
 	}
 	if (ac > 3) {
-		if (!strcmp(av[3], "normal"))
+		if (!vstrcmp(av[3], "normal"))
 			advice = MADV_NORMAL;
-		else if (!strcmp(av[3], "random"))
+		else if (!vstrcmp(av[3], "random"))
 			advice = MADV_RANDOM;
-		else if (!strcmp(av[3], "sequential"))
+		else if (!vstrcmp(av[3], "sequential"))
 			advice = MADV_SEQUENTIAL;
 		else
 			ARGV_ERR("(-s file) invalid advice: \"%s\"", av[3]);

--- a/bin/vinyld/storage/storage_persistent_subr.c
+++ b/bin/vinyld/storage/storage_persistent_subr.c
@@ -72,7 +72,7 @@ smp_def_sign(const struct smp_sc *sc, struct smp_signctx *ctx,
 {
 
 	AZ(off & 7);			/* Alignment */
-	assert(strlen(id) < sizeof ctx->ss->ident);
+	assert(vstrlen(id) < sizeof ctx->ss->ident);
 
 	memset(ctx, 0, sizeof *ctx);
 	ctx->ss = (void*)(sc->base + off);
@@ -143,7 +143,7 @@ smp_reset_sign(struct smp_signctx *ctx)
 {
 
 	memset(ctx->ss, 0, sizeof *ctx->ss);
-	assert(strlen(ctx->id) < sizeof *ctx->ss);
+	assert(vstrlen(ctx->id) < sizeof *ctx->ss);
 	strcpy(ctx->ss->ident, ctx->id);
 	ctx->ss->unique = ctx->unique;
 	ctx->ss->mapped = (uintptr_t)ctx->ss;
@@ -329,7 +329,7 @@ smp_valid_silo(struct smp_sc *sc)
 	struct smp_ident	*si;
 	int i, j;
 
-	assert(strlen(SMP_IDENT_STRING) < sizeof si->ident);
+	assert(vstrlen(SMP_IDENT_STRING) < sizeof si->ident);
 
 	i = smp_chk_sign(&sc->idn);
 	if (i)

--- a/bin/vinyld/storage/storage_persistent_subr.c
+++ b/bin/vinyld/storage/storage_persistent_subr.c
@@ -336,7 +336,7 @@ smp_valid_silo(struct smp_sc *sc)
 		return (i);
 
 	si = sc->ident;
-	if (strcmp(si->ident, SMP_IDENT_STRING))
+	if (vstrcmp(si->ident, SMP_IDENT_STRING))
 		return (12);
 	if (si->byte_order != 0x12345678)
 		return (13);

--- a/bin/vinyld/storage/storage_simple.c
+++ b/bin/vinyld/storage/storage_simple.c
@@ -711,8 +711,8 @@ sml_notify_init(struct sml_notify *sn)
 {
 
 	INIT_OBJ(sn, SML_NOTIFY_MAGIC);
-	AZ(pthread_mutex_init(&sn->mtx, NULL));
-	AZ(pthread_cond_init(&sn->cond, NULL));
+	PTOK(pthread_mutex_init(&sn->mtx, NULL));
+	PTOK(pthread_cond_init(&sn->cond, NULL));
 }
 
 static void
@@ -720,8 +720,8 @@ sml_notify_fini(struct sml_notify *sn)
 {
 
 	CHECK_OBJ_NOTNULL(sn, SML_NOTIFY_MAGIC);
-	AZ(pthread_mutex_destroy(&sn->mtx));
-	AZ(pthread_cond_destroy(&sn->cond));
+	PTOK(pthread_mutex_destroy(&sn->mtx));
+	PTOK(pthread_cond_destroy(&sn->cond));
 }
 
 static void v_matchproto_(vai_notify_cb)
@@ -731,10 +731,10 @@ sml_notify(vai_hdl hdl, void *priv)
 
 	(void) hdl;
 	CAST_OBJ_NOTNULL(sn, priv, SML_NOTIFY_MAGIC);
-	AZ(pthread_mutex_lock(&sn->mtx));
+	PTOK(pthread_mutex_lock(&sn->mtx));
 	sn->hasmore = 1;
-	AZ(pthread_cond_signal(&sn->cond));
-	AZ(pthread_mutex_unlock(&sn->mtx));
+	PTOK(pthread_cond_signal(&sn->cond));
+	PTOK(pthread_mutex_unlock(&sn->mtx));
 
 }
 
@@ -743,12 +743,12 @@ sml_notify_wait(struct sml_notify *sn)
 {
 
 	CHECK_OBJ_NOTNULL(sn, SML_NOTIFY_MAGIC);
-	AZ(pthread_mutex_lock(&sn->mtx));
+	PTOK(pthread_mutex_lock(&sn->mtx));
 	while (sn->hasmore == 0)
-		AZ(pthread_cond_wait(&sn->cond, &sn->mtx));
+		PTOK(pthread_cond_wait(&sn->cond, &sn->mtx));
 	AN(sn->hasmore);
 	sn->hasmore = 0;
-	AZ(pthread_mutex_unlock(&sn->mtx));
+	PTOK(pthread_mutex_unlock(&sn->mtx));
 }
 
 int v_matchproto_(objiterator_f)

--- a/bin/vinyld/storage/storage_simple.c
+++ b/bin/vinyld/storage/storage_simple.c
@@ -162,7 +162,7 @@ SML_allocobj(struct worker *wrk, const struct stevedore *stv,
 	if (st == NULL)
 		return (0);
 
-	CHECK_OBJ_NOTNULL(st, STORAGE_MAGIC);
+	CHECK_OBJ(st, STORAGE_MAGIC);
 	o = SML_MkObject(stv, oc, st->ptr);
 	CHECK_OBJ_NOTNULL(o, OBJECT_MAGIC);
 	st->len = sizeof(*o);

--- a/bin/vinyld/storage/storage_umem.c
+++ b/bin/vinyld/storage/storage_umem.c
@@ -398,7 +398,7 @@ static void v_matchproto_(storage_open_f)
 smu_open(struct stevedore *st)
 {
 	struct smu_sc *smu_sc;
-	char ident[strlen(st->ident) + 1];
+	char ident[vstrlen(st->ident) + 1];
 
 	ASSERT_CLI();
 	st->lru = LRU_Alloc();

--- a/bin/vinylhist/vinylhist.c
+++ b/bin/vinylhist/vinylhist.c
@@ -583,7 +583,7 @@ main(int argc, char **argv)
 	if (profile) {
 		for (active_profile = profiles; active_profile->name;
 		     active_profile++) {
-			if (strcmp(active_profile->name, profile) == 0)
+			if (vstrcmp(active_profile->name, profile) == 0)
 				break;
 		}
 	}

--- a/bin/vinylhist/vinylhist.c
+++ b/bin/vinylhist/vinylhist.c
@@ -299,7 +299,7 @@ accumulate(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 				if (active_profile->prefix &&
 				    strncmp(VSL_CDATA(tr->c->rec.ptr),
 				    active_profile->prefix,
-				    strlen(active_profile->prefix)) != 0)
+				    vstrlen(active_profile->prefix)) != 0)
 					break;
 
 				i = sscanf(VSL_CDATA(tr->c->rec.ptr),

--- a/bin/vinyllog/vinyllog.c
+++ b/bin/vinyllog/vinyllog.c
@@ -73,7 +73,7 @@ openout(int append)
 
 	AN(LOG.w_arg);
 	if (LOG.A_opt) {
-		if (!strcmp(LOG.w_arg, "-"))
+		if (!vstrcmp(LOG.w_arg, "-"))
 			LOG.fo = stdout;
 		else
 			LOG.fo = fopen(LOG.w_arg, append ? "a" : "w");
@@ -151,7 +151,7 @@ main(int argc, char * const *argv)
 	if (vut->D_opt && !LOG.w_arg)
 		VUT_Error(vut, 1, "Missing -w option");
 
-	if (vut->D_opt && !strcmp(LOG.w_arg, "-"))
+	if (vut->D_opt && !vstrcmp(LOG.w_arg, "-"))
 		VUT_Error(vut, 1, "Daemon cannot write to stdout");
 
 	/* Setup output */

--- a/bin/vinylncsa/vinylncsa.c
+++ b/bin/vinylncsa/vinylncsa.c
@@ -216,7 +216,7 @@ openout(int append)
 {
 
 	AN(CTX.w_arg);
-	if (!strcmp(CTX.w_arg, "-"))
+	if (!vstrcmp(CTX.w_arg, "-"))
 		CTX.fo = stdout;
 	else
 		CTX.fo = fopen(CTX.w_arg, append ? "a" : "w");
@@ -530,23 +530,23 @@ addf_time(char type, const char *fmt)
 	f->time_fmt = strdup(fmt);
 
 	if (f->time_type == 'T') {
-		if (!strcmp(fmt, "s"))
+		if (!vstrcmp(fmt, "s"))
 			f->time_type = 's';
-		else if (!strcmp(fmt, "ms"))
+		else if (!vstrcmp(fmt, "ms"))
 			f->time_type = 'm';
-		else if (!strcmp(fmt, "us"))
+		else if (!vstrcmp(fmt, "us"))
 			f->time_type = 'u';
 		else
 			VUT_Error(vut, 1, "Unknown specifier: %%{%s}T",
 			    fmt);
 		REPLACE(f->time_fmt, "%jd");
 	} else if (f->time_type == 't') {
-		if (!strcmp(fmt, "sec")) {
+		if (!vstrcmp(fmt, "sec")) {
 			f->time_type = 'S';
 			REPLACE(f->time_fmt, "%jd");
 		} else if (!strncmp(fmt, "msec", 4)) {
 			fmt += 4;
-			if (!strcmp(fmt, "_frac")) {
+			if (!vstrcmp(fmt, "_frac")) {
 				f->time_type = '3';
 				REPLACE(f->time_fmt, "%03jd");
 			} else if (*fmt == '\0') {
@@ -555,7 +555,7 @@ addf_time(char type, const char *fmt)
 			}
 		} else if (!strncmp(fmt, "usec", 4)) {
 			fmt += 4;
-			if (!strcmp(fmt, "_frac")) {
+			if (!vstrcmp(fmt, "_frac")) {
 				f->time_type = '6';
 				REPLACE(f->time_fmt, "%06jd");
 			} else if (*fmt == '\0') {
@@ -680,23 +680,23 @@ parse_x_format(char *buf)
 	long lval;
 	int slt;
 
-	if (!strcmp(buf, "Varnish:time_firstbyte")) {
+	if (!vstrcmp(buf, "Varnish:time_firstbyte")) {
 		addf_fragment(&CTX.frag[F_ttfb], CTX.missing_int);
 		return;
 	}
-	if (!strcmp(buf, "Varnish:hitmiss")) {
+	if (!vstrcmp(buf, "Varnish:hitmiss")) {
 		addf_strptr(&CTX.hitmiss);
 		return;
 	}
-	if (!strcmp(buf, "Varnish:handling")) {
+	if (!vstrcmp(buf, "Varnish:handling")) {
 		addf_strptr(&CTX.handling);
 		return;
 	}
-	if (!strcmp(buf, "Varnish:side")) {
+	if (!vstrcmp(buf, "Varnish:side")) {
 		addf_strptr(&CTX.side);
 		return;
 	}
-	if (!strcmp(buf, "Varnish:vxid")) {
+	if (!vstrcmp(buf, "Varnish:vxid")) {
 		addf_int64(&CTX.vxid);
 		return;
 	}
@@ -749,7 +749,7 @@ parse_x_format(char *buf)
 		addf_vsl((enum VSL_tag_e)slt, lval, r);
 		return;
 	}
-	if (!strcmp(buf, "Varnish:default_format")) {
+	if (!vstrcmp(buf, "Varnish:default_format")) {
 		parse_format(FORMAT);
 		return;
 	}
@@ -1181,10 +1181,10 @@ dispatch_f(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 				} else if (!strcasecmp(b, "hit")) {
 					CTX.hitmiss = "hit";
 					CTX.handling = "hit";
-				} else if (!strcasecmp(b, "miss") && strcmp(CTX.handling, "hitmiss")) {
+				} else if (!strcasecmp(b, "miss") && vstrcmp(CTX.handling, "hitmiss")) {
 					CTX.hitmiss = "miss";
 					CTX.handling = "miss";
-				} else if (!strcasecmp(b, "pass") && strcmp(CTX.handling, "hitpass")) {
+				} else if (!strcasecmp(b, "pass") && vstrcmp(CTX.handling, "hitpass")) {
 					CTX.hitmiss = "miss";
 					CTX.handling = "pass";
 				} else if (!strcasecmp(b, "synth")) {
@@ -1333,7 +1333,7 @@ main(int argc, char * const *argv)
 	if (vut->D_opt && !CTX.w_arg)
 		VUT_Error(vut, 1, "Missing -w option");
 
-	if (vut->D_opt && !strcmp(CTX.w_arg, "-"))
+	if (vut->D_opt && !vstrcmp(CTX.w_arg, "-"))
 		VUT_Error(vut, 1, "Daemon cannot write to stdout");
 
 	/* Check for valid grouping mode */

--- a/bin/vinylncsa/vinylncsa.c
+++ b/bin/vinylncsa/vinylncsa.c
@@ -969,7 +969,7 @@ frag_line(enum format_policy fp, const char *b, const char *e,
 	}
 
 	if (e == NULL)
-		e = b + strlen(b);
+		e = b + vstrlen(b);
 
 	/* Skip leading space */
 	while (b < e && isspace(*b))
@@ -1123,7 +1123,7 @@ dispatch_f(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 				    0, NULL);
 				break;
 			case SLT_Timestamp:
-#define ISPREFIX(a, b, c, d)	isprefix(a, strlen(a), b, c, d)
+#define ISPREFIX(a, b, c, d)	isprefix(a, vstrlen(a), b, c, d)
 				if (ISPREFIX("Start:", b, e, &p)) {
 					frag_fields(FMTPOL_INTERNAL, p, e, 1,
 					    &CTX.frag[F_tstart], 0, NULL);

--- a/bin/vinylstat/vinylstat.c
+++ b/bin/vinylstat/vinylstat.c
@@ -66,7 +66,7 @@ do_xml_cb(void *priv, const struct VSC_point * const pt)
 	(void)priv;
 	if (pt == NULL)
 		return (0);
-	AZ(strcmp(pt->ctype, "uint64_t"));
+	AZ(vstrcmp(pt->ctype, "uint64_t"));
 	val = VSC_Value(pt);
 
 	printf("\t<stat>\n");
@@ -105,7 +105,7 @@ do_json_cb(void *priv, const struct VSC_point * const pt)
 	if (pt == NULL)
 		return (0);
 
-	AZ(strcmp(pt->ctype, "uint64_t"));
+	AZ(vstrcmp(pt->ctype, "uint64_t"));
 	val = (uintmax_t)VSC_Value(pt);
 
 	sep = priv;
@@ -164,8 +164,8 @@ do_once_cb_first(void *priv, const struct VSC_point * const pt)
 	if (pt == NULL)
 		return (0);
 	op = priv;
-	AZ(strcmp(pt->ctype, "uint64_t"));
-	if (strcmp(pt->name, "MAIN.uptime"))
+	AZ(vstrcmp(pt->ctype, "uint64_t"));
+	if (vstrcmp(pt->name, "MAIN.uptime"))
 		return (0);
 	val = VSC_Value(pt);
 	op->up = (double)val;
@@ -182,7 +182,7 @@ do_once_cb(void *priv, const struct VSC_point * const pt)
 	if (pt == NULL)
 		return (0);
 	op = priv;
-	AZ(strcmp(pt->ctype, "uint64_t"));
+	AZ(vstrcmp(pt->ctype, "uint64_t"));
 	val = VSC_Value(pt);
 	i = 0;
 	i += printf("%s", pt->name);
@@ -281,7 +281,7 @@ main(int argc, char * const *argv)
 	int i;
 	struct vsc *vsc;
 
-	if (argc == 2 && !strcmp(argv[1], "--bindings"))
+	if (argc == 2 && !vstrcmp(argv[1], "--bindings"))
 		exit(key_bindings());
 
 	vut = VUT_InitProg(argc, argv, &vopt_spec);

--- a/bin/vinylstat/vinylstat_curses.c
+++ b/bin/vinylstat/vinylstat_curses.c
@@ -759,7 +759,7 @@ draw_line(WINDOW *w, int y, const struct pt *pt)
 	assert(colw_name >= COLW_NAME_MIN);
 	X = getmaxx(w);
 	x = 0;
-	if (strlen(pt->vpt->name) > colw_name)
+	if (vstrlen(pt->vpt->name) > colw_name)
 		IC(mvwprintw(w, y, x, "%.*s...", colw_name - 3, pt->vpt->name));
 	else
 		IC(mvwprintw(w, y, x, "%.*s", colw_name, pt->vpt->name));
@@ -867,13 +867,13 @@ draw_bar_b(void)
 	    page_start + l_points < n_ptarray ?
 		page_start + l_points : n_ptarray,
 	    n_ptarray);
-	IC(mvwprintw(w_bar_b, 0, X - strlen(buf), "%s", buf));
-	X -= strlen(buf) + 2;
+	IC(mvwprintw(w_bar_b, 0, X - vstrlen(buf), "%s", buf));
+	X -= vstrlen(buf) + 2;
 
 	if (verbosity != NULL) {
-		IC(mvwprintw(w_bar_b, 0, X - strlen(verbosity->label), "%s",
-		    verbosity->label));
-		X -= strlen(verbosity->label) + 2;
+		IC(mvwprintw(w_bar_b, 0, X - vstrlen(verbosity->label), "%s",
+			     verbosity->label));
+		X -= vstrlen(verbosity->label) + 2;
 	}
 	if (!hide_unseen) {
 		IC(mvwprintw(w_bar_b, 0, X - 6, "%s", "UNSEEN"));

--- a/bin/vinylstat/vinylstat_curses.c
+++ b/bin/vinylstat/vinylstat_curses.c
@@ -1127,15 +1127,15 @@ newpt(void *priv, const struct VSC_point *const vpt)
 	VTAILQ_INSERT_TAIL(&ptlist, pt, list);
 	n_ptlist++;
 
-	AZ(strcmp(vpt->ctype, "uint64_t"));
+	AZ(vstrcmp(vpt->ctype, "uint64_t"));
 
-	if (!strcmp(vpt->name, "MGT.uptime"))
+	if (!vstrcmp(vpt->name, "MGT.uptime"))
 		mgt_uptime = vpt->ptr;
-	if (!strcmp(vpt->name, "MAIN.uptime"))
+	if (!vstrcmp(vpt->name, "MAIN.uptime"))
 		main_uptime = vpt->ptr;
-	if (!strcmp(vpt->name, "MAIN.cache_hit"))
+	if (!vstrcmp(vpt->name, "MAIN.cache_hit"))
 		main_cache_hit = vpt->ptr;
-	if (!strcmp(vpt->name, "MAIN.cache_miss"))
+	if (!vstrcmp(vpt->name, "MAIN.cache_miss"))
 		main_cache_miss = vpt->ptr;
 	return (pt);
 }

--- a/bin/vinyltest/vtc_vinyl.c
+++ b/bin/vinyltest/vtc_vinyl.c
@@ -188,7 +188,7 @@ wait_stopped(const struct vinyl *v)
 		if (st != CLIS_OK)
 			vinyl_fatal(v,
 			    "CLI status command failed: %u %s", st, r);
-		if (!strcmp(r, "Child in state stopped")) {
+		if (!vstrcmp(r, "Child in state stopped")) {
 			free(r);
 			break;
 		}
@@ -213,10 +213,10 @@ wait_running(const struct vinyl *v)
 		if (st != CLIS_OK)
 			vinyl_fatal(v,
 			    "CLI status command failed: %u %s", st, r);
-		if (!strcmp(r, "Child in state stopped"))
+		if (!vstrcmp(r, "Child in state stopped"))
 			vinyl_fatal(v,
 			    "Child stopped before running: %u %s", st, r);
-		if (!strcmp(r, "Child in state running")) {
+		if (!vstrcmp(r, "Child in state running")) {
 			free(r);
 			r = NULL;
 			st = vinyl_ask_cli(v, "debug.listen_address", &r);
@@ -645,7 +645,7 @@ vinyl_listen(const struct vinyl *v, char *la)
 			first = 0;
 		}
 
-		if (!strcmp(n, n2))
+		if (!vstrcmp(n, n2))
 			continue;
 
 		bprintf(m, "%s_addr", n);
@@ -936,11 +936,11 @@ do_stat_dump_cb(void *priv, const struct VSC_point * const pt)
 	dp = priv;
 	v = dp->v;
 
-	if (strcmp(pt->ctype, "uint64_t"))
+	if (vstrcmp(pt->ctype, "uint64_t"))
 		return (0);
 	u = VSC_Value(pt);
 
-	if (strcmp(dp->arg, "*")) {
+	if (vstrcmp(dp->arg, "*")) {
 		if (fnmatch(dp->arg, pt->name, 0))
 			return (0);
 	}
@@ -998,7 +998,7 @@ do_expect_cb(void *priv, const struct VSC_point * const pt)
 		return (0);
 
 	if (!sp->lhs.good && stat_match(sp->lhs.pattern, pt->name) == 0) {
-		AZ(strcmp(pt->ctype, "uint64_t"));
+		AZ(vstrcmp(pt->ctype, "uint64_t"));
 		AN(pt->ptr);
 		sp->lhs.val = VSC_Value(pt);
 		sp->lhs.good = 1;
@@ -1008,7 +1008,7 @@ do_expect_cb(void *priv, const struct VSC_point * const pt)
 		sp->rhs.good = 1;
 	} else if (!sp->rhs.good &&
 	    stat_match(sp->rhs.pattern, pt->name) == 0) {
-		AZ(strcmp(pt->ctype, "uint64_t"));
+		AZ(vstrcmp(pt->ctype, "uint64_t"));
 		AN(pt->ptr);
 		sp->rhs.val = VSC_Value(pt);
 		sp->rhs.good = 1;
@@ -1259,7 +1259,7 @@ cmd_vinyl(CMD_ARGS)
 
 	VTC_CHECK_NAME(vl, av[0], "Vinyl", 'v');
 	VTAILQ_FOREACH(v, &vinyles, list)
-		if (!strcmp(v->name, av[0]))
+		if (!vstrcmp(v->name, av[0]))
 			break;
 	if (v == NULL) {
 		v = vinyl_new(av[0]);
@@ -1272,7 +1272,7 @@ cmd_vinyl(CMD_ARGS)
 	for (; *av != NULL; av++) {
 		if (vtc_error)
 			break;
-		if (!strcmp(*av, "-arg")) {
+		if (!vstrcmp(*av, "-arg")) {
 			AN(av[1]);
 			AZ(v->pid);
 			VSB_cat(v->args, " ");
@@ -1282,25 +1282,25 @@ cmd_vinyl(CMD_ARGS)
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-cleanup")) {
+		if (!vstrcmp(*av, "-cleanup")) {
 			AZ(av[1]);
 			vinyl_cleanup(v);
 			continue;
 		}
-		if (!strcmp(*av, "-cli")) {
+		if (!vstrcmp(*av, "-cli")) {
 			AN(av[1]);
 			vinyl_cli(v, av[1], 0, NULL, 0);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-clierr")) {
+		if (!vstrcmp(*av, "-clierr")) {
 			AN(av[1]);
 			AN(av[2]);
 			vinyl_cli(v, av[2], atoi(av[1]), NULL, 0);
 			av += 2;
 			continue;
 		}
-		if (!strcmp(*av, "-cliexpect")) {
+		if (!vstrcmp(*av, "-cliexpect")) {
 			int neg = 0;
 
 			AN(av[1]);
@@ -1314,19 +1314,19 @@ cmd_vinyl(CMD_ARGS)
 			av += 2;
 			continue;
 		}
-		if (!strcmp(*av, "-clijson")) {
+		if (!vstrcmp(*av, "-clijson")) {
 			AN(av[1]);
 			vinyl_cli_json(v, av[1]);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-cliok")) {
+		if (!vstrcmp(*av, "-cliok")) {
 			AN(av[1]);
 			vinyl_cli(v, av[1], (unsigned)CLIS_OK, NULL, 0);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-errvcl")) {
+		if (!vstrcmp(*av, "-errvcl")) {
 			char *r = NULL;
 			AN(av[1]);
 			AN(av[2]);
@@ -1343,76 +1343,76 @@ cmd_vinyl(CMD_ARGS)
 			av += 2;
 			continue;
 		}
-		if (!strcmp(*av, "-expect")) {
+		if (!vstrcmp(*av, "-expect")) {
 			av++;
 			vinyl_expect(v, av);
 			av += 2;
 			continue;
 		}
-		if (!strcmp(*av, "-expectexit")) {
+		if (!vstrcmp(*av, "-expectexit")) {
 			v->expect_exit = strtoul(av[1], NULL, 0);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-jail")) {
+		if (!vstrcmp(*av, "-jail")) {
 			AN(av[1]);
 			AZ(v->pid);
 			REPLACE(v->jail, av[1]);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-proto")) {
+		if (!vstrcmp(*av, "-proto")) {
 			AN(av[1]);
 			AZ(v->pid);
 			REPLACE(v->proto, av[1]);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-start")) {
+		if (!vstrcmp(*av, "-start")) {
 			vinyl_start(v);
 			continue;
 		}
-		if (!strcmp(*av, "-stop")) {
+		if (!vstrcmp(*av, "-stop")) {
 			vinyl_stop(v);
 			continue;
 		}
-		if (!strcmp(*av, "-syntax")) {
+		if (!vstrcmp(*av, "-syntax")) {
 			AN(av[1]);
 			v->syntax = strtod(av[1], NULL);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-vcl")) {
+		if (!vstrcmp(*av, "-vcl")) {
 			AN(av[1]);
 			vinyl_vcl(v, av[1], 0, NULL);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-vcl+backend")) {
+		if (!vstrcmp(*av, "-vcl+backend")) {
 			AN(av[1]);
 			vinyl_vclbackend(v, av[1]);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-vsc")) {
+		if (!vstrcmp(*av, "-vsc")) {
 			AN(av[1]);
 			vinyl_vsc(v, av[1]);
 			av++;
 			continue;
 		}
-		if (!strcmp(*av, "-wait-stopped")) {
+		if (!vstrcmp(*av, "-wait-stopped")) {
 			wait_stopped(v);
 			continue;
 		}
-		if (!strcmp(*av, "-wait-running")) {
+		if (!vstrcmp(*av, "-wait-running")) {
 			wait_running(v);
 			continue;
 		}
-		if (!strcmp(*av, "-wait")) {
+		if (!vstrcmp(*av, "-wait")) {
 			vinyl_wait(v);
 			continue;
 		}
-		if (!strcmp(*av, "-vsl_catchup")) {
+		if (!vstrcmp(*av, "-vsl_catchup")) {
 			vsl_catchup(v);
 			continue;
 		}

--- a/bin/vinyltest/vtc_vinyl.c
+++ b/bin/vinyltest/vtc_vinyl.c
@@ -150,8 +150,8 @@ vinyl_ask_cli(const struct vinyl *v, const char *cmd, char **repl)
 
 	if (cmd != NULL) {
 		vtc_dump(v->vl, 4, "CLI TX", cmd, -1);
-		i = write(v->cli_fd, cmd, strlen(cmd));
-		if (i != strlen(cmd) && !vtc_stop)
+		i = write(v->cli_fd, cmd, vstrlen(cmd));
+		if (i != vstrlen(cmd) && !vtc_stop)
 			vinyl_fatal(v, "CLI write failed (%s) = %u %s",
 			    cmd, errno, strerror(errno));
 		i = write(v->cli_fd, "\n", 1);

--- a/bin/vinyltop/vinyltop.c
+++ b/bin/vinyltop/vinyltop.c
@@ -208,7 +208,7 @@ update(unsigned p)
 		n++;
 	AC(erase());
 	q = ident;
-	len = COLS - strlen(q);
+	len = COLS - vstrlen(q);
 	if (end_of_file)
 		IC(mvprintw(0, len - (1 + 6), "%s (EOF)", q));
 	else
@@ -248,8 +248,8 @@ do_curses(void *arg)
 	for (i = 0; i < 256; i++) {
 		if (VSL_tags[i] == NULL)
 			continue;
-		if (maxfieldlen < strlen(VSL_tags[i]))
-			maxfieldlen = strlen(VSL_tags[i]);
+		if (maxfieldlen < vstrlen(VSL_tags[i]))
+			maxfieldlen = vstrlen(VSL_tags[i]);
 	}
 
 	(void)initscr();

--- a/include/vdef.h
+++ b/include/vdef.h
@@ -64,7 +64,7 @@
 /* Safe strcpy into a fixed-size buffer */
 #define bstrcpy(dst, src)						\
 	do {								\
-		assert(strlen(src) + 1 <= sizeof (dst));		\
+		assert(vstrlen(src) + 1 <= sizeof (dst));		\
 		strcpy((dst), (src));					\
 	} while (0)
 
@@ -284,8 +284,8 @@ typedef struct {
 
 #define Tcheck(t)	do { (void)pdiff((t).b, (t).e); } while (0)
 #define Tlen(t)		(pdiff((t).b, (t).e))
-#define Tstr(s)		(/*lint -e(446)*/ (txt){(s), (s) + strlen(s)})
-#define Tstreq(t, s)	(Tlen(t) == strlen(s) && !vmemcmp((t).b, (s), Tlen(t)))
+#define Tstr(s)		(/*lint -e(446)*/ (txt){(s), (s) + vstrlen(s)})
+#define Tstreq(t, s)	(Tlen(t) == vstrlen(s) && !vmemcmp((t).b, (s), Tlen(t)))
 #define Tforeach(c, t)	for ((c) = (t).b; (c) < (t).e; (c)++)
 
 /* #3020 dummy definitions until PR is merged*/

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -786,7 +786,7 @@ typedef const struct {
 	do {								\
 		AN(hdr);						\
 		assert((hdr)->len > 0);					\
-		assert((hdr)->len == strlen((hdr)->str));		\
+		assert((hdr)->len == vstrlen((hdr)->str));		\
 		assert((hdr)->str[(hdr)->len - 1] == ':');		\
 	} while (0)
 

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -592,7 +592,7 @@ vcc_ParseHostDef(struct vcc *tl, struct symbol *sym,
 			AN(via->rname);
 
 			if (via->extra != NULL) {
-				AZ(strcmp(via->extra, "via"));
+				AZ(vstrcmp(via->extra, "via"));
 				VSB_cat(tl->sb,
 					"Cannot stack .via backends at\n");
 				vcc_ErrWhere(tl, tl->t);

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -955,9 +955,9 @@ VCC_Predef(struct vcc *vcc, const char *type, const char *name)
 {
 
 	CHECK_OBJ_NOTNULL(vcc, VCC_MAGIC);
-	if (!strcmp(type, "VCL_STEVEDORE"))
+	if (!vstrcmp(type, "VCL_STEVEDORE"))
 		vcc_stevedore(vcc, name);
-	else if (!strcmp(type, "VCL_VCL"))
+	else if (!vstrcmp(type, "VCL_VCL"))
 		vcc_predef_vcl(vcc, name);
 	else
 		WRONG("Unknown VCC predef type");

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -115,7 +115,7 @@ TlDup(struct vcc *tl, const char *s)
 {
 	char *p;
 
-	p = TlAlloc(tl, strlen(s) + 1);
+	p = TlAlloc(tl, vstrlen(s) + 1);
 	AN(p);
 	strcpy(p, s);
 	return (p);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -163,8 +163,9 @@ vcc_strands_edit(const struct expr *e1, const struct expr *e2)
 
 	if (e2->fmt == STRANDS)
 		VSB_cat(e1->vsb, VSB_data(e2->vsb));
-	else if (e2->nstr == 0)
-		VSB_printf(e1->vsb, "vrt_null_strands");
+	else if (e2->nstr == 0) {
+		VSB_cat(e1->vsb, "vrt_null_strands");
+	}
 	else if (e2->nstr == 1)
 		VSB_printf(e1->vsb, "TOSTRAND(%s)", VSB_data(e2->vsb));
 	else {

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -649,7 +649,7 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 			e1 = vcc_expr_edit(tl, e1->fmt, ssa, e1, NULL);
 		}
 		if (fa->result == NULL && fa->type == ENUM && fa->val != NULL)
-			fa->result = vcc_do_enum(tl, cfunc, strlen(fa->val), fa->val);
+			fa->result = vcc_do_enum(tl, cfunc, vstrlen(fa->val), fa->val);
 		if (fa->result == NULL && fa->val != NULL) {
 			if (fa->type == BOOL && fa->val[0] == 'f')
 				fa->result = vcc_mk_expr(fa->type, "0");

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -414,10 +414,10 @@ vcc_priv_arg(struct vcc *tl, const char *p, struct symbol *sym)
 	AN(sym);
 	AN(sym->vmod_name);
 
-	if (!strcmp(p, "PRIV_VCL"))
+	if (!vstrcmp(p, "PRIV_VCL"))
 		return (vcc_mk_expr(VOID, "&vmod_priv_%s", sym->vmod_name));
 
-	if (!strcmp(p, "PRIV_CALL")) {
+	if (!vstrcmp(p, "PRIV_CALL")) {
 		bprintf(buf, "vmod_priv_%u", tl->unique++);
 		ifp = New_IniFin(tl);
 		Fh(tl, 0, "static struct vmod_priv %s;\n", buf);
@@ -425,9 +425,9 @@ vcc_priv_arg(struct vcc *tl, const char *p, struct symbol *sym)
 		return (vcc_mk_expr(VOID, "&%s", buf));
 	}
 
-	if (!strcmp(p, "PRIV_TASK"))
+	if (!vstrcmp(p, "PRIV_TASK"))
 		f = "task";
-	else if (!strcmp(p, "PRIV_TOP")) {
+	else if (!vstrcmp(p, "PRIV_TOP")) {
 		f = "top";
 		sym->r_methods &= VCL_MET_TASK_C;
 	} else {

--- a/lib/libvcc/vcc_source.c
+++ b/lib/libvcc/vcc_source.c
@@ -235,8 +235,8 @@ vcc_lex_source(struct vcc *tl, struct source *src_sp, int eoi)
 	CHECK_OBJ_NOTNULL(src_sp, SOURCE_MAGIC);
 
 	for (sp1 = src_sp->parent; sp1 != NULL; sp1 = sp1->parent) {
-		if (!strcmp(sp1->name, src_sp->name) &&
-		    !strcmp(sp1->kind, src_sp->kind)) {
+		if (!vstrcmp(sp1->name, src_sp->name) &&
+		    !vstrcmp(sp1->kind, src_sp->kind)) {
 			VSB_printf(tl->sb,
 			    "Recursive use of %s \"%s\"\n\n",
 			    src_sp->kind, src_sp->name);

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -213,7 +213,7 @@ vcc_sym_in_tab(struct vcc *tl, struct symtab *st,
 		if (kind == SYM_NONE && kind == sym->kind &&
 		    sym->wildcard == NULL)
 			continue;
-		if (tl->syntax < VCL_41 && strcmp(sym->name, "default") &&
+		if (tl->syntax < VCL_41 && vstrcmp(sym->name, "default") &&
 		     kind != SYM_NONE && kind != sym->kind &&
 		     sym->wildcard == NULL)
 			continue;

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -133,7 +133,7 @@ vcc_symtab_new(const char *name)
 	ALLOC_OBJ(st, SYMTAB_MAGIC);
 	AN(st);
 	st->name = name;
-	st->nlen = strlen(st->name);
+	st->nlen = vstrlen(st->name);
 	VTAILQ_INIT(&st->children);
 	VTAILQ_INIT(&st->symbols);
 	return (st);

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -259,7 +259,7 @@ vcc_type_t
 VCC_Type(const char *p)
 {
 
-#define VCC_TYPE(UC, lc)	if (!strcmp(p, #UC)) return (UC);
+#define VCC_TYPE(UC, lc)	if (!vstrcmp(p, #UC)) return (UC);
 #include "vcc_types.h"
 	return (NULL);
 }

--- a/lib/libvcc/vcc_var.c
+++ b/lib/libvcc/vcc_var.c
@@ -71,7 +71,7 @@ vcc_Var_Wildcard(struct vcc *tl, struct symbol *parent, struct symbol *sym)
 	AN(sym);
 	assert(parent->type == HEADER);
 
-	if (strlen(sym->name) >= 127) {
+	if (vstrlen(sym->name) >= 127) {
 		VSB_printf(tl->sb, "HTTP header (%.20s..) is too long.\n",
 		    sym->name);
 		tl->err = 1;

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -155,7 +155,7 @@ vcc_ParseJSON(const struct vcc *tl, const char *jsn, struct vmod_import *vim)
 	AN(vv3);
 	if (!vjsn_is_string(vv3))
 		return ("Not string[2]");
-	if (strcmp(vv3->value, "$VMOD"))
+	if (vstrcmp(vv3->value, "$VMOD"))
 		return ("Not $VMOD[3]");
 
 	vv3 = VTAILQ_NEXT(vv3, list);
@@ -199,7 +199,7 @@ vcc_ParseJSON(const struct vcc *tl, const char *jsn, struct vmod_import *vim)
 
 
 	if (vim->major == 0 && vim->minor == 0 &&
-	    strcmp(vim->abi, VMOD_ABI_Version)) {
+	    vstrcmp(vim->abi, VMOD_ABI_Version)) {
 		VSB_printf(tl->sb, "Incompatible VMOD %.*s\n", PF(vim->t_mod));
 		VSB_printf(tl->sb, "\tFile name: %s\n", vim->path);
 		VSB_printf(tl->sb, "\tABI mismatch, expected <%s>, got <%s>\n",
@@ -225,7 +225,7 @@ vcc_ParseJSON(const struct vcc *tl, const char *jsn, struct vmod_import *vim)
 		assert(vjsn_is_string(vv3));
 		assert(vv3->value[0] == '$');
 #define STANZA(UU, ll, ss) \
-    if (!strcmp(vv3->value, "$" #UU)) {vim->n_##ll++; continue;}
+    if (!vstrcmp(vv3->value, "$" #UU)) {vim->n_##ll++; continue;}
 		STANZA_TBL
 #undef STANZA
 		return ("Unknown metadata stanza.");
@@ -261,9 +261,9 @@ vcc_VmodLoad(struct vcc *tl, struct vmod_import *vim)
 		return (-1);
 
 	VTAILQ_FOREACH(vim2, &imports, list) {
-		if (strcmp(vim->name, vim2->name))
+		if (vstrcmp(vim->name, vim2->name))
 			continue;
-		if (!strcmp(vim->file_id, vim2->file_id)) {
+		if (!vstrcmp(vim->file_id, vim2->file_id)) {
 			// (Truly) duplicate imports are OK
 			return (0);
 		}
@@ -324,7 +324,7 @@ vcc_vj_foreach(struct vcc *tl, const struct vmod_import *vim,
 		assert (vjsn_is_array(vv2));
 		vv3 = VTAILQ_FIRST(&vv2->children);
 		assert (vjsn_is_string(vv3));
-		if (!strcmp(vv3->value, stanza))
+		if (!vstrcmp(vv3->value, stanza))
 			func(tl, vim, VTAILQ_NEXT(vv3, list));
 	}
 }
@@ -523,7 +523,7 @@ vcc_ParseImport(struct vcc *tl)
 	vimold = msym->import;
 	if (vimold != NULL) {
 		CHECK_OBJ(vimold, VMOD_IMPORT_MAGIC);
-		if (!strcmp(vimold->file_id, vim->file_id)) {
+		if (!vstrcmp(vimold->file_id, vim->file_id)) {
 			/* Identical import is OK */
 		} else {
 			VSB_printf(tl->sb,
@@ -541,7 +541,7 @@ vcc_ParseImport(struct vcc *tl)
 		assert(vsym->kind == SYM_VMOD);
 		vimold = vsym->import;
 		CHECK_OBJ_NOTNULL(vimold, VMOD_IMPORT_MAGIC);
-		if (!strcmp(vimold->file_id, vim->file_id)) {
+		if (!vstrcmp(vimold->file_id, vim->file_id)) {
 			/* Already loaded under different name */
 			msym->eval_priv = vsym->eval_priv;
 			msym->import = vsym->import;

--- a/lib/libvcc/vcc_vmod_sym.c
+++ b/lib/libvcc/vcc_vmod_sym.c
@@ -123,7 +123,7 @@ func_restrict(struct vcc *tl, struct symbol *sym, vcc_kind_t kind, const struct 
 	vv = VTAILQ_FIRST(&v->children);
 	AN(vv);
 	assert(vjsn_is_string(vv));
-	if (strcmp(vv->value, "$RESTRICT"))
+	if (vstrcmp(vv->value, "$RESTRICT"))
 		return;
 	vv = VTAILQ_NEXT(vv, list);
 	AN(vv);
@@ -134,7 +134,7 @@ func_restrict(struct vcc *tl, struct symbol *sym, vcc_kind_t kind, const struct 
 	while (vv) {
 		s = 0;
 #define VCL_CTX(l,H)							\
-		if (strcmp(vv->value, #l) == 0) s = VCL_MET_##H;
+		if (vstrcmp(vv->value, #l) == 0) s = VCL_MET_##H;
 #include "tbl/vcl_context.h"
 		if (!s) {
 			VSB_printf(tl->sb, "Error in vmod \"%s\", invalid scope for $Restrict: %s\n",sym->vmod_name, vv->value);
@@ -276,7 +276,7 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 	// vv = flags
 	assert(vjsn_is_object(vv));
 	VTAILQ_FOREACH(vf, &vv->children, list)
-		if (!strcmp(vf->name, "NULL_OK") && vjsn_is_true(vf))
+		if (!vstrcmp(vf->name, "NULL_OK") && vjsn_is_true(vf))
 			null_ok = 1;
 	if (!null_ok)
 		VTAILQ_INSERT_TAIL(&tl->sym_objects, isym, sideways);
@@ -290,7 +290,7 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 	vf = VTAILQ_FIRST(&vv->children);
 	vv = VTAILQ_NEXT(vv, list);
 	assert(vjsn_is_string(vf));
-	assert(!strcmp(vf->value, "$INIT"));
+	assert(!vstrcmp(vf->value, "$INIT"));
 
 	vf = VTAILQ_NEXT(vf, list);
 
@@ -306,7 +306,7 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 
 	vf = VTAILQ_FIRST(&vv->children);
 	assert(vjsn_is_string(vf));
-	assert(!strcmp(vf->value, "$FINI"));
+	assert(!vstrcmp(vf->value, "$FINI"));
 
 	vf = VTAILQ_NEXT(vf, list);
 	vf = VTAILQ_FIRST(&vf->children);

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -429,7 +429,7 @@ vcc_xreftable_len(struct vcc *tl, const struct symbol *sym)
 	(void)tl;
 	CHECK_OBJ_NOTNULL(sym, SYMBOL_MAGIC);
 	CHECK_OBJ_NOTNULL(sym->type, TYPE_MAGIC);
-	len = strlen(sym->type->name);
+	len = vstrlen(sym->type->name);
 	if (sym_type_len < len)
 		sym_type_len = len;
 }

--- a/lib/libvinyl/vav.c
+++ b/lib/libvinyl/vav.c
@@ -453,7 +453,7 @@ test_run(const struct test_case *tc, int *ret)
 	}
 
 	for (i = 1; i < argc && tc->argv[i] != NULL && argv[i] != NULL; i++) {
-		if (!strcmp(tc->argv[i], argv[i]))
+		if (!vstrcmp(tc->argv[i], argv[i]))
 			continue;
 		printf(
 		    "ERROR: Parsing string <%s> with flags %x, "

--- a/lib/libvinyl/vav.c
+++ b/lib/libvinyl/vav.c
@@ -429,7 +429,7 @@ test_run(const struct test_case *tc, int *ret)
 	char **argv, *tmp;
 	int argc, i;
 
-	i = strlen(tc->str);
+	i = vstrlen(tc->str);
 	if (i == 0) {
 		argv = VAV_Parse(tc->str, &argc, tc->flag);
 	} else {

--- a/lib/libvinyl/vbt.c
+++ b/lib/libvinyl/vbt.c
@@ -166,7 +166,7 @@ VBT_dump(size_t len, char buf[len])
 	if (VSB_init(vsb, buf, len) == NULL)
 		return (-1);
 
-	VSB_printf(vsb, "Backtrace:\n");
+	VSB_cat(vsb, "Backtrace:\n");
 	VSB_indent(vsb, 2);
 	VBT_format(vsb);
 	VSB_indent(vsb, -2);

--- a/lib/libvinyl/vbt.c
+++ b/lib/libvinyl/vbt.c
@@ -124,8 +124,8 @@ vbt_execinfo(struct vsb *vsb)
 			VSB_cat(vsb, "(?)");
 		} else {
 			p = strings[0];
-			if (!memcmp(buf, p, strlen(buf))) {
-				p += strlen(buf);
+			if (!memcmp(buf, p, vstrlen(buf))) {
+				p += vstrlen(buf);
 				if (*p == ':')
 					p++;
 				while (*p == ' ')

--- a/lib/libvinyl/vcli_proto.c
+++ b/lib/libvinyl/vcli_proto.c
@@ -87,7 +87,7 @@ VCLI_WriteResult(int fd, unsigned status, const char *result)
 	assert(status >= 100);
 	assert(status <= 999);		/*lint !e650 const out of range */
 
-	len = strlen(result);
+	len = vstrlen(result);
 
 	i = snprintf(res, sizeof res, "%-3d %-8zd\n", status, len);
 	assert(i == CLI_LINE0_LEN);

--- a/lib/libvinyl/vcli_serve.c
+++ b/lib/libvinyl/vcli_serve.c
@@ -147,9 +147,9 @@ VCLS_func_help(struct cli *cli, const char * const *av, void *priv)
 	CHECK_OBJ_NOTNULL(cs, VCLS_MAGIC);
 
 	for (av += 2; av[0] != NULL && av[0][0] == '-'; av++) {
-		if (!strcmp(av[0], "-a")) {
+		if (!vstrcmp(av[0], "-a")) {
 			filter = 3;
-		} else if (!strcmp(av[0], "-d")) {
+		} else if (!vstrcmp(av[0], "-d")) {
 			filter = 2;
 		} else {
 			VCLI_Out(cli, "Unknown flag\n");
@@ -164,7 +164,7 @@ VCLS_func_help(struct cli *cli, const char * const *av, void *priv)
 			continue;
 		if (clp->desc->flags & CLI_F_HIDDEN)
 			continue;
-		if (av[0] != NULL && !strcmp(clp->desc->request, av[0])) {
+		if (av[0] != NULL && !vstrcmp(clp->desc->request, av[0])) {
 			help_helper(cli, clp, av);
 			return;
 		} else if (av[0] == NULL) {
@@ -246,7 +246,7 @@ cls_dispatch(struct cli *cli, const struct cli_proto *cp,
 
 	VSB_clear(cli->sb);
 
-	if (na > 1 && !strcmp(av[2], "-j"))
+	if (na > 1 && !vstrcmp(av[2], "-j"))
 		json = 1;
 
 	if (cp->func == NULL && !json) {
@@ -462,7 +462,7 @@ cls_feed(struct VCLS_fd *cfd, const char *p, const char *e)
 			if (cli->auth > 0 &&
 			    av[0] == NULL &&
 			    ac >= 3 &&
-			    !strcmp(av[ac-2], "<<") &&
+			    !vstrcmp(av[ac - 2], "<<") &&
 			    *av[ac - 1] != '\0') {
 				/* Go to "<< nonce" mode */
 				cfd->argv = av;
@@ -617,12 +617,12 @@ VCLS_AddFunc(struct VCLS *cs, struct cli_proto *clp)
 	AN(clp);
 
 	for (;clp->desc != NULL; clp++) {
-		if (!strcmp(clp->desc->request, "*")) {
+		if (!vstrcmp(clp->desc->request, "*")) {
 			cs->wildcard = clp;
 		} else {
 			i = 0;
 			VTAILQ_FOREACH(clp2, &cs->funcs, list) {
-				i = strcmp(clp->desc->request,
+				i = vstrcmp(clp->desc->request,
 				    clp2->desc->request);
 				if (i <= 0)
 					break;

--- a/lib/libvinyl/vcli_serve.c
+++ b/lib/libvinyl/vcli_serve.c
@@ -400,7 +400,7 @@ cls_exec(struct VCLS_fd *cfd, char * const *av)
 		if (cli->result == CLIS_OK)
 			cli->result = CLIS_TRUNCATED;
 		s[lim - 1] = '\0';
-		assert(strlen(s) <= lim);
+		assert(vstrlen(s) <= lim);
 	}
 	if (VCLI_WriteResult(cfd->fdo, cli->result, s) ||
 	    cli->result == CLIS_CLOSE)

--- a/lib/libvinyl/vjsn.c
+++ b/lib/libvinyl/vjsn.c
@@ -477,11 +477,11 @@ vjsn_dump_i(const struct vjsn_val *jsv, FILE *fo, int indent)
 		printf("[\"%s\"]: ", jsv->name);
 	printf("{%s}", jsv->type);
 	if (jsv->value != NULL) {
-		if (strlen(jsv->value) < 20)
+		if (vstrlen(jsv->value) < 20)
 			printf(" <%s", jsv->value);
 		else
 			printf(" <%.10s[...#%zu]",
-			    jsv->value, strlen(jsv->value + 10));
+			    jsv->value, vstrlen(jsv->value + 10));
 		printf(">");
 	}
 	printf("\n");

--- a/lib/libvinyl/vjsn.c
+++ b/lib/libvinyl/vjsn.c
@@ -460,7 +460,7 @@ vjsn_child(const struct vjsn_val *vv, const char *key)
 	CHECK_OBJ_NOTNULL(vv, VJSN_VAL_MAGIC);
 	AN(key);
 	VTAILQ_FOREACH(vc, &vv->children, list) {
-		if (vc->name != NULL && !strcmp(vc->name, key))
+		if (vc->name != NULL && !vstrcmp(vc->name, key))
 			return (vc);
 	}
 	return (NULL);

--- a/lib/libvinyl/vnum.c
+++ b/lib/libvinyl/vnum.c
@@ -632,7 +632,7 @@ main(int argc, char *argv[])
 		consumed = input - tspn->input;
 		bprintf(buf1, "%.4f", dbl);
 		bprintf(buf2, "%.4f", tspn->retval);
-		if (strcmp(buf1, buf2) ||
+		if (vstrcmp(buf1, buf2) ||
 		    consumed != tspn->consumed ||
 		    errtxt != tspn->errtxt) {
 			ec++;

--- a/lib/libvinyl/vpf.c
+++ b/lib/libvinyl/vpf.c
@@ -159,8 +159,8 @@ VPF_Write(const struct vpf_fh *pfh)
 	AZ(ftruncate(pfh->pf_fd, 0));
 
 	bprintf(pidstr, "%jd", (intmax_t)getpid());
-	assert(pwrite(pfh->pf_fd, pidstr, strlen(pidstr), 0) ==
-	    (ssize_t)strlen(pidstr));
+	assert(pwrite(pfh->pf_fd, pidstr, vstrlen(pidstr), 0) ==
+	       (ssize_t) vstrlen(pidstr));
 }
 
 void

--- a/lib/libvinyl/vsa.c
+++ b/lib/libvinyl/vsa.c
@@ -256,7 +256,7 @@ VSA_GetPtr(const struct suckaddr *sua, const unsigned char ** dst)
 	AN(dst);
 	if (sua == NULL)
 		return (-1);
-	CHECK_OBJ_NOTNULL(sua, SUCKADDR_MAGIC);
+	CHECK_OBJ(sua, SUCKADDR_MAGIC);
 
 	switch (sua->u.sa.sa_family) {
 	case PF_INET:

--- a/lib/libvinyl/vsb.c
+++ b/lib/libvinyl/vsb.c
@@ -328,7 +328,7 @@ VSB_cat(struct vsb *s, const char *str)
 		str += l;
 	}
 
-	l = strlen(str);
+	l = vstrlen(str);
 	return (VSB_bcat(s, str, l));
 }
 
@@ -545,15 +545,15 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 	assert(p != NULL);
 	if (how & VSB_QUOTE_ABBREVIATE) {
 		assert (len > 5);
-		if (strlen(v) < (unsigned)len) {
-			len = strlen(v);
+		if (vstrlen(v) < (unsigned)len) {
+			len = vstrlen(v);
 			how &= ~VSB_QUOTE_ABBREVIATE;
 		} else {
 			len -= 5;
 		}
 	}
 	if (len == -1)
-		len = strlen(v);
+		len = vstrlen(v);
 
 	if (len == 0 && (how & VSB_QUOTE_CSTR)) {
 		VSB_printf(s, "%s\"\"", pfx);

--- a/lib/libvinyl/vsb_test.c
+++ b/lib/libvinyl/vsb_test.c
@@ -163,7 +163,7 @@ main(int argc, char *argv[])
 		VSB_cat(vsbo, " (");
 		VSB_quote(vsbo, tc->out, -1, VSB_QUOTE_ESCHEX);
 		VSB_cat(vsbo, ")");
-		if (strcmp(VSB_data(vsb), tc->out)) {
+		if (vstrcmp(VSB_data(vsb), tc->out)) {
 			VSB_cat(vsbo, "\nShould have been:\n\t");
 			VSB_quote(vsbo, tc->out, -1, VSB_QUOTE_HEX);
 			VSB_cat(vsbo, "\nThat's:\n\t");

--- a/lib/libvinyl/vsha256.c
+++ b/lib/libvinyl/vsha256.c
@@ -368,7 +368,7 @@ VSHA256_Test(void)
 
 	for (p = sha256test; p->input != NULL; p++) {
 		VSHA256_Init(&c);
-		VSHA256_Update(&c, p->input, strlen(p->input));
+		VSHA256_Update(&c, p->input, vstrlen(p->input));
 		VSHA256_Final(o, &c);
 		AZ(memcmp(o, p->output, 32));
 	}

--- a/lib/libvinyl/vte.c
+++ b/lib/libvinyl/vte.c
@@ -381,7 +381,7 @@ main(int argc, char **argv)
 	assert(vte->f_maxsz[1] == 3);
 	assert(vte->f_maxsz[2] == 8);
 
-	if (strcmp(VSB_data(vsb), test_fmt)) {
+	if (vstrcmp(VSB_data(vsb), test_fmt)) {
 		fprintf(stderr,
 		    "Error: VTE output mismatch\n"
 		    "<<<<<<<\n"

--- a/lib/libvinyl/vtim.c
+++ b/lib/libvinyl/vtim.c
@@ -312,9 +312,9 @@ vtim_parse_http(struct tm *tm, const char **pp)
 			DIGIT(10, year);
 			DIGIT(1, year);
 		} else if (!strncmp(p, more_weekday[tm->tm_wday],
-		    strlen(more_weekday[tm->tm_wday]))) {
+		    vstrlen(more_weekday[tm->tm_wday]))) {
 			/* RFC850 -- "Sunday, 06-Nov-94 08:49:37 GMT" */
-			p += strlen(more_weekday[tm->tm_wday]);
+			p += vstrlen(more_weekday[tm->tm_wday]);
 			MUSTBE(',');
 			MUSTBE(' ');
 			DIGIT(10, mday);

--- a/lib/libvinyl/vtim.c
+++ b/lib/libvinyl/vtim.c
@@ -638,7 +638,7 @@ main(int argc, char **argv)
 		gmtime_r(&t, &tm);
 		strftime(buf1, sizeof buf1, "%a, %d %b %Y %T GMT", &tm);
 		VTIM_format(t, buf);
-		if (strcmp(buf, buf1)) {
+		if (vstrcmp(buf, buf1)) {
 			printf("libc: <%s> Vtim <%s> %jd\n",
 			    buf1, buf, (intmax_t)t);
 			exit(2);

--- a/lib/libvinyl/vtim.c
+++ b/lib/libvinyl/vtim.c
@@ -71,6 +71,7 @@
 #include "vdef.h"
 
 #include "vas.h"
+#include "vct.h"
 #include "vtim.h"
 
 /* relax vtim parsing */
@@ -243,18 +244,15 @@ VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE])
 		DIGIT(1, sec);					\
 	} while(0)
 
-vtim_real
-VTIM_parse(const char *p)
+static unsigned
+vtim_parse_http(struct tm *tm, const char **pp)
 {
-	struct tm tm[1] = {{.tm_wday = -1 }};
-	vtim_real t;
-	int d, leap;
+	const char *p;
 
-	if (p == NULL || *p == '\0')
+	AN(pp);
+	p = *pp;
+	if (*p == '\0')
 		FAIL();
-
-	while (*p == ' ')
-		p++;
 
 	if (*p >= '0' && *p <= '9') {
 		/* ISO8601 -- "1994-11-06T08:49:37" */
@@ -339,11 +337,15 @@ VTIM_parse(const char *p)
 			FAIL();
 	}
 
-	while (*p == ' ')
-		p++;
+	*pp = p;
+	return (1);
+}
 
-	if (*p != '\0')
-		FAIL();
+static vtim_real
+vtim_calc(struct tm *tm)
+{
+	vtim_real t;
+	int d, leap;
 
 	if (tm->tm_sec < 0 || tm->tm_sec > 60)	/* Leapseconds! */
 		FAIL();
@@ -397,6 +399,29 @@ VTIM_parse(const char *p)
 	t += 10957. * 86400.;	/* 10957 days frm UNIX epoch to y2000 */
 
 	return (t);
+}
+
+vtim_real
+VTIM_parse(const char *p)
+{
+	struct tm tm[1] = {{.tm_wday = -1 }};
+
+	if (p == NULL)
+		FAIL();
+
+	while (vct_isows(*p))
+		p++;
+
+	if (!vtim_parse_http(tm, &p))
+		FAIL();
+
+	while (vct_isows(*p))
+		p++;
+
+	if (*p != '\0')
+		FAIL();
+
+	return (vtim_calc(tm));
 }
 
 void

--- a/lib/libvinyl/vtim.c
+++ b/lib/libvinyl/vtim.c
@@ -191,7 +191,7 @@ VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE])
 	do {							\
 		if (*p < '0' || *p > '9')			\
 			FAIL();					\
-		fld += (*p - '0') * mult;			\
+		tm->tm_##fld += (*p - '0') * mult;		\
 		p++;						\
 	} while(0)
 
@@ -207,7 +207,7 @@ VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE])
 		int i;						\
 		for (i = 0; i < 7; i++) {			\
 			if (!strncmp(p, weekday_name[i], 3)) {	\
-				weekday = i;			\
+				tm->tm_wday = i;		\
 				break;				\
 			}					\
 		}						\
@@ -222,7 +222,7 @@ VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE])
 		int i;						\
 		for (i = 0; i < 12; i++) {			\
 			if (!strncmp(p, month_name[i], 3)) {	\
-				month = i + 1;			\
+				tm->tm_mon = i + 1;		\
 				break;				\
 			}					\
 		}						\
@@ -246,9 +246,8 @@ VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE])
 vtim_real
 VTIM_parse(const char *p)
 {
+	struct tm tm[1] = {{.tm_wday = -1 }};
 	vtim_real t;
-	int month = 0, year = 0, weekday = -1, mday = 0;
-	int hour = 0, min = 0, sec = 0;
 	int d, leap;
 
 	if (p == NULL || *p == '\0')
@@ -264,8 +263,8 @@ VTIM_parse(const char *p)
 		DIGIT(10, year);
 		DIGIT(1, year);
 		MUSTBE('-');
-		DIGIT(10, month);
-		DIGIT(1, month);
+		DIGIT(10, mon);
+		DIGIT(1, mon);
 		MUSTBE('-');
 		DIGIT(10, mday);
 		DIGIT(1, mday);
@@ -273,7 +272,7 @@ VTIM_parse(const char *p)
 		TIMESTAMP();
 	} else {
 		WEEKDAY();
-		assert(weekday >= 0 && weekday <= 6);
+		assert(tm->tm_wday >= 0 && tm->tm_wday <= 6);
 		if (*p == ',') {
 			/* RFC822 & RFC1123 - "Sun, 06 Nov 1994 08:49:37 GMT" */
 			p++;
@@ -314,10 +313,10 @@ VTIM_parse(const char *p)
 			DIGIT(100, year);
 			DIGIT(10, year);
 			DIGIT(1, year);
-		} else if (!strncmp(p, more_weekday[weekday],
-		    strlen(more_weekday[weekday]))) {
+		} else if (!strncmp(p, more_weekday[tm->tm_wday],
+		    strlen(more_weekday[tm->tm_wday]))) {
 			/* RFC850 -- "Sunday, 06-Nov-94 08:49:37 GMT" */
-			p += strlen(more_weekday[weekday]);
+			p += strlen(more_weekday[tm->tm_wday]);
 			MUSTBE(',');
 			MUSTBE(' ');
 			DIGIT(10, mday);
@@ -327,9 +326,9 @@ VTIM_parse(const char *p)
 			MUSTBE('-');
 			DIGIT(10, year);
 			DIGIT(1, year);
-			year += 1900;
-			if (year < 1969)
-				year += 100;
+			tm->tm_year += 1900;
+			if (tm->tm_year < 1969)
+				tm->tm_year += 100;
 			MUSTBE(' ');
 			TIMESTAMP();
 			MUSTBE(' ');
@@ -346,56 +345,56 @@ VTIM_parse(const char *p)
 	if (*p != '\0')
 		FAIL();
 
-	if (sec < 0 || sec > 60)	/* Leapseconds! */
+	if (tm->tm_sec < 0 || tm->tm_sec > 60)	/* Leapseconds! */
 		FAIL();
-	if (min < 0 || min > 59)
+	if (tm->tm_min < 0 || tm->tm_min > 59)
 		FAIL();
-	if (hour < 0 || hour > 23)
+	if (tm->tm_hour < 0 || tm->tm_hour > 23)
 		FAIL();
-	if (month < 1 || month > 12)
+	if (tm->tm_mon < 1 || tm->tm_mon > 12)
 		FAIL();
-	if (mday < 1 || mday > days_in_month[month - 1])
+	if (tm->tm_mday < 1 || tm->tm_mday > days_in_month[tm->tm_mon - 1])
 		FAIL();
-	if (year < 1899)
-		FAIL();
-
-	leap =
-	    ((year) % 4) == 0 && (((year) % 100) != 0 || ((year) % 400) == 0);
-
-	if (month == 2 && mday > 28 && !leap)
+	if (tm->tm_year < 1899)
 		FAIL();
 
-	if (sec == 60)			/* Ignore Leapseconds */
-		sec--;
+	leap = ((tm->tm_year) % 4) == 0 &&
+	    (((tm->tm_year) % 100) != 0 || ((tm->tm_year) % 400) == 0);
 
-	t = ((hour * 60.) + min) * 60. + sec;
+	if (tm->tm_mon == 2 && tm->tm_mday > 28 && !leap)
+		FAIL();
 
-	d = (mday - 1) + days_before_month[month - 1];
+	if (tm->tm_sec == 60)			/* Ignore Leapseconds */
+		tm->tm_sec--;
 
-	if (month > 2 && leap)
+	t = ((tm->tm_hour * 60.) + tm->tm_min) * 60. + tm->tm_sec;
+
+	d = (tm->tm_mday - 1) + days_before_month[tm->tm_mon - 1];
+
+	if (tm->tm_mon > 2 && leap)
 		d++;
 
-	d += (year % 100) * 365;	/* There are 365 days in a year */
+	d += (tm->tm_year % 100) * 365;	/* There are 365 days in a year */
 
-	if ((year % 100) > 0)		/* And a leap day every four years */
-		d += (((year % 100) - 1) / 4);
+	if ((tm->tm_year % 100) > 0)	/* And a leap day every four years */
+		d += (((tm->tm_year % 100) - 1) / 4);
 
-	d += ((year / 100) - 20) *	/* Days relative to y2000 */
+	d += ((tm->tm_year / 100) - 20) *	/* Days relative to y2000 */
 	    (100 * 365 + 24);		/* 24 leapdays per year in a century */
 
-	d += ((year - 1) / 400) - 4;	/* And one more every 400 years */
+	d += ((tm->tm_year - 1) / 400) - 4;	/* One more every 400 years */
 
 	/*
 	 * Now check weekday, if we have one.
 	 * 6 is because 2000-01-01 was a saturday.
 	 * 10000 is to make sure the modulus argument is always positive
 	 */
-	if (weekday != -1 && (d + 6 + 7 * 10000) % 7 != weekday)
+	if (tm->tm_wday != -1 && (d + 6 + 7 * 10000) % 7 != tm->tm_wday)
 		FAIL();
 
 	t += d * 86400.;
 
-	t += 10957. * 86400.;		/* 10957 days frm UNIX epoch to y2000 */
+	t += 10957. * 86400.;	/* 10957 days frm UNIX epoch to y2000 */
 
 	return (t);
 }

--- a/lib/libvinyl/vus.c
+++ b/lib/libvinyl/vus.c
@@ -51,7 +51,7 @@ sun_init(struct sockaddr_un *uds, const char *path, const char **err)
 	if (err)
 		*err = NULL;
 
-	if (strlen(path) + 1 > sizeof(uds->sun_path)) {
+	if (vstrlen(path) + 1 > sizeof(uds->sun_path)) {
 		errno = ENAMETOOLONG;
 		if (err)
 			*err = "Path too long for a Unix domain socket";

--- a/lib/libvinyl/vus.c
+++ b/lib/libvinyl/vus.c
@@ -57,7 +57,7 @@ sun_init(struct sockaddr_un *uds, const char *path, const char **err)
 			*err = "Path too long for a Unix domain socket";
 		return (-1);
 	}
-	if (! strcmp(path, "@")) {
+	if (! vstrcmp(path, "@")) {
 		errno = EINVAL;
 		if (err)
 			*err = "The empty abstract socket name is not"

--- a/lib/libvinylapi/vsc.c
+++ b/lib/libvinylapi/vsc.c
@@ -276,11 +276,11 @@ vsc_fill_point(const struct vsc *vsc, const struct vsc_seg *seg,
 	AN(vt);
 	assert(vjsn_is_string(vt));
 
-	if (!strcmp(vt->value, "counter")) {
+	if (!vstrcmp(vt->value, "counter")) {
 		point->point.semantics = 'c';
-	} else if (!strcmp(vt->value, "gauge")) {
+	} else if (!vstrcmp(vt->value, "gauge")) {
 		point->point.semantics = 'g';
-	} else if (!strcmp(vt->value, "bitmap")) {
+	} else if (!vstrcmp(vt->value, "bitmap")) {
 		point->point.semantics = 'b';
 	} else {
 		point->point.semantics = '?';
@@ -290,13 +290,13 @@ vsc_fill_point(const struct vsc *vsc, const struct vsc_seg *seg,
 	AN(vt);
 	assert(vjsn_is_string(vt));
 
-	if (!strcmp(vt->value, "integer")) {
+	if (!vstrcmp(vt->value, "integer")) {
 		point->point.format = 'i';
-	} else if (!strcmp(vt->value, "bytes")) {
+	} else if (!vstrcmp(vt->value, "bytes")) {
 		point->point.format = 'B';
-	} else if (!strcmp(vt->value, "bitmap")) {
+	} else if (!vstrcmp(vt->value, "bitmap")) {
 		point->point.format = 'b';
-	} else if (!strcmp(vt->value, "duration")) {
+	} else if (!vstrcmp(vt->value, "duration")) {
 		point->point.format = 'd';
 	} else {
 		point->point.format = '?';
@@ -306,11 +306,11 @@ vsc_fill_point(const struct vsc *vsc, const struct vsc_seg *seg,
 	AN(vt);
 	assert(vjsn_is_string(vt));
 
-	if (!strcmp(vt->value, "info"))  {
+	if (!vstrcmp(vt->value, "info"))  {
 		point->point.level = &levels[info];
-	} else if (!strcmp(vt->value, "diag")) {
+	} else if (!vstrcmp(vt->value, "diag")) {
 		point->point.level = &levels[diag];
-	} else if (!strcmp(vt->value, "debug")) {
+	} else if (!vstrcmp(vt->value, "debug")) {
 		point->point.level = &levels[debug];
 	} else {
 		WRONG("Illegal level");
@@ -560,9 +560,9 @@ VSC_Iter(struct vsc *vsc, struct vsm *vsm, VSC_iter_f *fiter, void *priv)
 	sp = VTAILQ_FIRST(&vsc->segs);
 	VSM_FOREACH(&ifantom, vsm) {
 		AN(ifantom.category);
-		if (!strcmp(ifantom.category, VSC_CLASS))
+		if (!vstrcmp(ifantom.category, VSC_CLASS))
 			type = VSC_SEG_COUNTERS;
-		else if (!strcmp(ifantom.category, VSC_DOC_CLASS))
+		else if (!vstrcmp(ifantom.category, VSC_DOC_CLASS))
 			type = VSC_SEG_DOCS;
 		else {
 			/* Not one of the categories we care about */
@@ -572,7 +572,7 @@ VSC_Iter(struct vsc *vsc, struct vsm *vsm, VSC_iter_f *fiter, void *priv)
 		while (sp != NULL) {
 			CHECK_OBJ_NOTNULL(sp, VSC_SEG_MAGIC);
 			if (VSM_StillValid(vsm, sp->fantom) == VSM_valid &&
-			    !strcmp(ifantom.ident, sp->fantom->ident)) {
+			    !vstrcmp(ifantom.ident, sp->fantom->ident)) {
 				/* sp matches the expected value */
 				break;
 			}

--- a/lib/libvinylapi/vsl.c
+++ b/lib/libvinylapi/vsl.c
@@ -417,7 +417,7 @@ VSL_WriteOpen(struct VSL_data *vsl, const char *name, int append, int unbuf)
 {
 	FILE* f;
 
-	if (!strcmp(name, "-"))
+	if (!vstrcmp(name, "-"))
 		f = stdout;
 	else
 		f = fopen(name, append ? "a" : "w");

--- a/lib/libvinylapi/vsl_arg.c
+++ b/lib/libvinylapi/vsl_arg.c
@@ -65,12 +65,12 @@ VSL_Name2Tag(const char *name, int l)
 	int i, n;
 
 	if (l == -1)
-		l = strlen(name);
+		l = vstrlen(name);
 	n = -1;
 	for (i = 0; i < SLT__MAX; i++) {
 		if (VSL_tags[i] != NULL &&
 		    !strncasecmp(name, VSL_tags[i], l)) {
-			if (strlen(VSL_tags[i]) == l) {
+			if (vstrlen(VSL_tags[i]) == l) {
 				/* Exact match */
 				return (i);
 			}
@@ -189,11 +189,11 @@ VSLQ_Name2Grouping(const char *name, int l)
 
 	AN(name);
 	if (l == -1)
-		l = strlen(name);
+		l = vstrlen(name);
 	n = -1;
 	for (i = 0; i < VSL_g__MAX; i++) {
 		if (!strncasecmp(name, VSLQ_grouping[i], l)) {
-			if (strlen(VSLQ_grouping[i]) == l) {
+			if (vstrlen(VSLQ_grouping[i]) == l) {
 				/* Exact match */
 				return (i);
 			}
@@ -336,7 +336,7 @@ vsl_R_arg(struct VSL_data *vsl, const char *arg)
 	if (*p != '/' || p[1] == '\0')
 		return (vsl_diag(vsl, "-R: Syntax error"));
 	p++;
-	if (strlen(p) > sizeof(buf) - 2)
+	if (vstrlen(p) > sizeof(buf) - 2)
 		return (vsl_diag(vsl, "-R: Syntax error"));
 	if (!isdigit(*p))
 		strcat(buf, "1");

--- a/lib/libvinylapi/vsl_cursor.c
+++ b/lib/libvinylapi/vsl_cursor.c
@@ -536,7 +536,7 @@ VSL_CursorFile(struct VSL_data *vsl, const char *name, unsigned options)
 	AN(name);
 	(void)options;
 
-	if (!strcmp(name, "-"))
+	if (!vstrcmp(name, "-"))
 		fd = STDIN_FILENO;
 	else {
 		fd = open(name, O_RDONLY);

--- a/lib/libvinylapi/vsl_dispatch.c
+++ b/lib/libvinylapi/vsl_dispatch.c
@@ -849,7 +849,7 @@ vtx_scan_link(struct VSLQ *vslq, struct vtx *vtx, const uint32_t *ptr)
 		return (0);
 	}
 
-	CHECK_OBJ_NOTNULL(c_vtx, VTX_MAGIC);
+	CHECK_OBJ(c_vtx, VTX_MAGIC);
 	if (c_vtx->parent == vtx)
 		/* Link already exists */
 		return (0);

--- a/lib/libvinylapi/vsl_dispatch.c
+++ b/lib/libvinylapi/vsl_dispatch.c
@@ -709,7 +709,7 @@ vtx_parse_link(const char *str, enum VSL_transaction_e *ptype,
 
 	/* transaction type */
 	for (et = VSL_t_unknown; et < VSL_t__MAX; et++)
-		if (!strcmp(type, vsl_t_names[et]))
+		if (!vstrcmp(type, vsl_t_names[et]))
 			break;
 	if (et >= VSL_t__MAX)
 		et = VSL_t_unknown;
@@ -725,7 +725,7 @@ vtx_parse_link(const char *str, enum VSL_transaction_e *ptype,
 
 	/* transaction reason */
 	for (er = VSL_r_unknown; er < VSL_r__MAX; er++)
-		if (!strcmp(reason, vsl_r_names[er]))
+		if (!vstrcmp(reason, vsl_r_names[er]))
 			break;
 	if (er >= VSL_r__MAX)
 		er = VSL_r_unknown;

--- a/lib/libvinylapi/vsm.c
+++ b/lib/libvinylapi/vsm.c
@@ -999,7 +999,7 @@ VSM_Map(struct vsm *vd, struct vsm_fantom *vf)
 		return (0);
 	}
 
-	CHECK_OBJ_NOTNULL(vgc, VSM_SEG_MAGIC);
+	CHECK_OBJ(vgc, VSM_SEG_MAGIC);
 	assert(vgc->flags & VSM_FLAG_CLUSTER);
 	assert(vg->s == NULL);
 	assert(vg->sz == 0);
@@ -1040,7 +1040,7 @@ VSM_Unmap(struct vsm *vd, struct vsm_fantom *vf)
 	vg = vsm_findseg(vd, vf);
 	if (vg == NULL)
 		return (vsm_diag(vd, "VSM_Unmap: bad fantom"));
-	CHECK_OBJ_NOTNULL(vg, VSM_SEG_MAGIC);
+	CHECK_OBJ(vg, VSM_SEG_MAGIC);
 	assert(vg->refs > 0);
 	vg->refs--;
 	vf->b = NULL;

--- a/lib/libvinylapi/vsm.c
+++ b/lib/libvinylapi/vsm.c
@@ -466,7 +466,7 @@ vsm_cmp_av(char * const *a1, char * const *a2)
 			return (0);
 		if (*a1 == NULL || *a2 == NULL)
 			return (1);
-		if (strcmp(*a1, *a2))
+		if (vstrcmp(*a1, *a2))
 			return (1);
 		a1++;
 		a2++;
@@ -481,7 +481,7 @@ vsm_findcluster(const struct vsm_set *vs, const char *cnam)
 	AN(cnam);
 	VTAILQ_FOREACH(vg, &vs->clusters, clist) {
 		AN(vg->av[1]);
-		if (!strcmp(cnam, vg->av[1]))
+		if (!vstrcmp(cnam, vg->av[1]))
 			return (vg);
 	}
 	return (NULL);
@@ -1094,9 +1094,9 @@ VSM_Get(struct vsm *vd, struct vsm_fantom *vf,
 	CHECK_OBJ_NOTNULL(vd, VSM_MAGIC);
 	AN(vd->attached);
 	VSM_FOREACH(vf, vd) {
-		if (strcmp(vf->category, category))
+		if (vstrcmp(vf->category, category))
 			continue;
-		if (ident != NULL && strcmp(vf->ident, ident))
+		if (ident != NULL && vstrcmp(vf->ident, ident))
 			continue;
 		return (1);
 	}
@@ -1115,9 +1115,9 @@ VSM_Dup(struct vsm *vd, const char *category, const char *ident)
 	CHECK_OBJ_NOTNULL(vd, VSM_MAGIC);
 	AN(vd->attached);
 	VSM_FOREACH(&vf, vd) {
-		if (strcmp(vf.category, category))
+		if (vstrcmp(vf.category, category))
 			continue;
-		if (ident != NULL && strcmp(vf.ident, ident))
+		if (ident != NULL && vstrcmp(vf.ident, ident))
 			continue;
 		AZ(VSM_Map(vd, &vf));
 		AN(vf.b);

--- a/lib/libvinylapi/vut.c
+++ b/lib/libvinylapi/vut.c
@@ -249,11 +249,11 @@ VUT_Init(const char *progname, int argc, char * const *argv,
 	VSIG_Arm_term();
 	VSIG_Arm_usr1();
 
-	if (argc == 2 && !strcmp(argv[1], "--synopsis"))
+	if (argc == 2 && !vstrcmp(argv[1], "--synopsis"))
 		exit(vut_synopsis(voc));
-	if (argc == 2 && !strcmp(argv[1], "--options"))
+	if (argc == 2 && !vstrcmp(argv[1], "--options"))
 		exit(vut_options(voc));
-	if (argc == 2 && !strcmp(argv[1], "--optstring")) {
+	if (argc == 2 && !vstrcmp(argv[1], "--optstring")) {
 		(void)printf("%s\n", voc->vopt_optstring);
 		exit(0);
 	}
@@ -305,7 +305,7 @@ VUT_Setup(struct VUT *vut)
 	    (vut->r_arg == NULL ? 0 : 2) > 2)
 		VUT_Error(vut, 1, "Only one of -n and -r options may be used");
 
-	if (vut->r_arg != NULL && !strcmp(vut->r_arg, "-") && vut->D_opt)
+	if (vut->r_arg != NULL && !vstrcmp(vut->r_arg, "-") && vut->D_opt)
 		VUT_Error(vut, 1, "Daemon cannot read from stdin");
 
 	/* Create and validate the query expression */

--- a/lib/libvinylapi/vut.c
+++ b/lib/libvinylapi/vut.c
@@ -549,7 +549,7 @@ print_nobrackets(const char *s)
 	/* Remove whitespace */
 	while (isspace(*s))
 		s++;
-	e = s + strlen(s);
+	e = s + vstrlen(s);
 	while (e > s && isspace(e[-1]))
 		e--;
 

--- a/lib/libvinylapi/vxp.c
+++ b/lib/libvinylapi/vxp.c
@@ -208,7 +208,7 @@ vex_New(const char *query, struct vsb *sb, unsigned options)
 	AN(sb);
 	vxp = vxp_New(sb);
 	vxp->b = query;
-	vxp->e = query + strlen(query);
+	vxp->e = query + vstrlen(query);
 	vxp->vex_options = options;
 	if (options & VEX_OPT_CASELESS)
 		vxp->vre_options |= VRE_CASELESS;

--- a/lib/libvinylapi/vxp_parse.c
+++ b/lib/libvinylapi/vxp_parse.c
@@ -157,7 +157,7 @@ vxp_expr_lhs(struct vxp *vxp, struct vex_lhs **plhs)
 		AN(vxp->t->dec);
 		(*plhs)->prefix = strdup(vxp->t->dec);
 		AN((*plhs)->prefix);
-		(*plhs)->prefixlen = strlen((*plhs)->prefix);
+		(*plhs)->prefixlen = vstrlen((*plhs)->prefix);
 		vxp_NextToken(vxp);
 	}
 
@@ -249,7 +249,7 @@ vxp_expr_str(struct vxp *vxp, struct vex_rhs **prhs)
 	(*prhs)->type = VEX_STRING;
 	(*prhs)->val_string = strdup(vxp->t->dec);
 	AN((*prhs)->val_string);
-	(*prhs)->val_stringlen = strlen((*prhs)->val_string);
+	(*prhs)->val_stringlen = vstrlen((*prhs)->val_string);
 	vxp_NextToken(vxp);
 }
 
@@ -669,7 +669,7 @@ vex_print(const struct vex *vex, int indent)
 		vex_print_tags(vex->lhs->tags);
 		fprintf(stderr, ")");
 		if (vex->lhs->prefix) {
-			assert(vex->lhs->prefixlen == strlen(vex->lhs->prefix));
+			assert(vex->lhs->prefixlen == vstrlen(vex->lhs->prefix));
 			fprintf(stderr, ":%s", vex->lhs->prefix);
 		}
 		if (vex->lhs->field > 0)

--- a/tools/coccinelle/check_obj.cocci
+++ b/tools/coccinelle/check_obj.cocci
@@ -19,3 +19,22 @@ expression obj, magicval;
 
 - assert(obj->magic == magicval);
 + CHECK_OBJ(obj, magicval);
+
+@@
+expression obj, magicval;
+@@
+
+(
+if (obj == NULL) {
+    ...
+    return(...);
+}
+|
+if (obj == NULL)
+    return(...);
+)
+...
+when != (obj = ...)
+- CHECK_OBJ_NOTNULL(obj, magicval);
++ CHECK_OBJ(obj, magicval);
+...

--- a/tools/coccinelle/vstringy.cocci
+++ b/tools/coccinelle/vstringy.cocci
@@ -9,3 +9,10 @@ idexpression x;
 
 -strlen(x)
 +vstrlen(x)
+
+@@
+idexpression x, y;
+@@
+
+-strcmp(x, y)
++vstrcmp(x, y)

--- a/tools/coccinelle/vstringy.cocci
+++ b/tools/coccinelle/vstringy.cocci
@@ -1,0 +1,11 @@
+/*
+ * Replace strlen, strcmp, memcmp etc. with our v* variants, which allow
+ * compilers to make better optimizations for constant values
+ */
+
+@@
+idexpression x;
+@@
+
+-strlen(x)
++vstrlen(x)

--- a/vmod/vmod_blob.c
+++ b/vmod/vmod_blob.c
@@ -147,7 +147,7 @@ decode_l(enum encoding dec, VCL_STRANDS s)
 	CHECK_OBJ_NOTNULL(s, STRANDS_MAGIC);
 	for (int i = 0; i < s->n; i++)
 		if (s->p[i] != NULL && *s->p[i] != '\0')
-			len += strlen(s->p[i]);
+			len += vstrlen(s->p[i]);
 
 	return (func[dec].decode_l(len));
 }

--- a/vmod/vmod_blob_id.c
+++ b/vmod/vmod_blob_id.c
@@ -89,7 +89,7 @@ id_decode(const enum encoding enc, blob_dest_t buf,
 		s = strings->p[i];
 		if (s == NULL || *s == '\0')
 			continue;
-		len = strlen(s);
+		len = vstrlen(s);
 		if (len > c)
 			len = c;
 		c -= len;

--- a/vmod/vmod_cookie.c
+++ b/vmod/vmod_cookie.c
@@ -154,7 +154,7 @@ find_cookie(const struct vmod_cookie *vcp, VCL_STRING name)
 
 	VTAILQ_FOREACH(cookie, &vcp->cookielist, list) {
 		CHECK_OBJ_NOTNULL(cookie, VMOD_COOKIE_ENTRY_MAGIC);
-		if (!strcmp(cookie->name, name))
+		if (!vstrcmp(cookie->name, name))
 			break;
 	}
 	return (cookie);
@@ -331,7 +331,7 @@ filter_cookies(struct vmod_priv *priv, VCL_STRING list_s,
 		matched = 0;
 
 		VTAILQ_FOREACH(mlentry, &matchlist_head, list) {
-			if (strcmp(cookieptr->name, mlentry->name) == 0) {
+			if (vstrcmp(cookieptr->name, mlentry->name) == 0) {
 				matched = 1;
 				break;
 			}

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -83,16 +83,16 @@ xyzzy_author(VRT_CTX, VCL_ENUM person, VCL_ENUM someone)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (person == VENUM(phk))
 		return ("Poul-Henning");
-	assert(strcmp(person, "phk"));
+	assert(vstrcmp(person, "phk"));
 	if (person == VENUM(des))
 		return ("Dag-Erling");
-	assert(strcmp(person, "des"));
+	assert(vstrcmp(person, "des"));
 	if (person == VENUM(kristian))
 		return ("Kristian");
-	assert(strcmp(person, "kristian"));
+	assert(vstrcmp(person, "kristian"));
 	if (person == VENUM(mithrandir))
 		return ("Tollef");
-	assert(strcmp(person, "mithrandir"));
+	assert(vstrcmp(person, "mithrandir"));
 	WRONG("Illegal VMOD enum");
 }
 
@@ -133,7 +133,7 @@ xyzzy_test_priv_call(VRT_CTX, struct vmod_priv *priv)
 		priv->methods = xyzzy_test_priv_call_methods;
 	} else {
 		assert(priv->methods == xyzzy_test_priv_call_methods);
-		assert(!strcmp(priv->priv, "BAR"));
+		assert(!vstrcmp(priv->priv, "BAR"));
 	}
 }
 
@@ -1273,7 +1273,7 @@ resolve_cb(void *priv, const struct suckaddr *sa)
 	CHECK_OBJ_NOTNULL(p->vsb, VSB_MAGIC);
 	AN(sa);
 	VTCP_name(sa, abuf, sizeof abuf, pbuf, sizeof pbuf);
-	if (p->fail_port != NULL && !strcmp(p->fail_port, pbuf)) {
+	if (p->fail_port != NULL && !vstrcmp(p->fail_port, pbuf)) {
 		*(p->errp) = "bad port";
 		return (-1);
 	}

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -160,7 +160,7 @@ xyzzy_test_priv_task(VRT_CTX, struct vmod_priv *priv, VCL_STRING s)
 		    priv, priv->priv);
 	} else {
 		char *n = realloc(priv->priv,
-		    strlen(priv->priv) + strlen(s) + 2);
+		    vstrlen(priv->priv) + vstrlen(s) + 2);
 		if (n == NULL)
 			return (NULL);
 		strcat(n, " ");
@@ -336,7 +336,7 @@ event_load(VRT_CTX, struct vmod_priv *priv)
 	AN(priv_vcl->foo);
 	priv_vcl->tmpf = mkstemp(priv_vcl->foo);
 	assert(priv_vcl->tmpf >= 0);
-	AN(write(priv_vcl->tmpf, priv_vcl->foo, strlen(priv_vcl->foo)));
+	AN(write(priv_vcl->tmpf, priv_vcl->foo, vstrlen(priv_vcl->foo)));
 	priv->priv = priv_vcl;
 	priv->methods = priv_vcl_methods;
 
@@ -636,7 +636,7 @@ xyzzy_concat__init(VRT_CTX, struct xyzzy_debug_concat **concatp,
 
 	for (int i = 0; i < s->n; i++)
 		if (s->p[i] != NULL)
-			sz += strlen(s->p[i]);
+			sz += vstrlen(s->p[i]);
 	p = malloc(sz + 1);
 	AN(p);
 	(void)VRT_Strands(p, sz + 1, s);
@@ -1387,7 +1387,8 @@ xyzzy_log_strands(VRT_CTX, VCL_STRING prefix, VCL_STRANDS subject, VCL_INT nn)
 	for (i = 0; i < subject->n; i++) {
 		const char *p = subject->p[i];
 		mylog(ctx->vsl, SLT_Debug, "%s[%d]: (%s) %p %.*s%s", prefix, i,
-		    ptr_where(ctx, p), p, n, p, strlen(p) > (unsigned)n ? "..." : "");
+		    ptr_where(ctx, p), p, n, p,
+		    vstrlen(p) > (unsigned)n ? "..." : "");
 	}
 }
 

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -297,7 +297,7 @@ priv_vcl_fini(VRT_CTX, void *priv)
 	struct priv_vcl *priv_vcl;
 
 	CAST_OBJ_NOTNULL(priv_vcl, priv, PRIV_VCL_MAGIC);
-	AZ(close(priv_vcl->tmpf));
+	closefd(&priv_vcl->tmpf);
 	AN(priv_vcl->foo);
 	AZ(unlink(priv_vcl->foo));
 	free(priv_vcl->foo);

--- a/vmod/vmod_debug_filters.c
+++ b/vmod/vmod_debug_filters.c
@@ -814,7 +814,7 @@ xyzzy_string_init(VRT_CTX, struct vdp_ctx *vdc, void **priv)
 	}
 	AN(p->priv);
 	*priv = p->priv;
-	*vdc->clen = strlen(*priv);
+	*vdc->clen = vstrlen(*priv);
 	return (0);
 }
 
@@ -829,7 +829,7 @@ xyzzy_string_bytes(struct vdp_ctx *vdc, enum vdp_action act, void **priv,
 	(void)ptr;
 	(void)len;
 
-	r = VDP_bytes(vdc, VDP_END, *priv, strlen(*priv));
+	r = VDP_bytes(vdc, VDP_END, *priv, vstrlen(*priv));
 	if (r != 0)
 		return (r);
 	// only to be called once
@@ -891,7 +891,7 @@ xyzzy_vdp_body_prefix_init(VRT_CTX, struct vdp_ctx *vdc, void **priv)
 
 	l = 0;
 	VSTAILQ_FOREACH(bps, &bp->head, list)
-		l += strlen(bps->s);
+		l += vstrlen(bps->s);
 	*vdc->clen += l;
 
 	return (0);
@@ -909,7 +909,7 @@ xyzzy_vdp_body_prefix_bytes(struct vdp_ctx *vdc, enum vdp_action act, void **pri
 
 	while ((bps = VSTAILQ_FIRST(&bp->head)) != NULL) {
 		VSTAILQ_REMOVE_HEAD(&bp->head, list);
-		if (VDP_bytes(vdc, VDP_NULL, bps->s, strlen(bps->s)))
+		if (VDP_bytes(vdc, VDP_NULL, bps->s, vstrlen(bps->s)))
 			return (vdc->retval);
 	}
 

--- a/vmod/vmod_debug_obj.c
+++ b/vmod/vmod_debug_obj.c
@@ -61,7 +61,7 @@ xyzzy_obj__init(VRT_CTX, struct xyzzy_debug_obj **op,
 	AN(op);
 	AZ(*op);
 
-	if (! strcmp(s, "fail")) {
+	if (! vstrcmp(s, "fail")) {
 		VRT_fail(ctx, "failing as requested");
 	}
 	ALLOC_OBJ(o, VMOD_DEBUG_OBJ_MAGIC);
@@ -89,7 +89,7 @@ xyzzy_obj_enum(VRT_CTX, struct xyzzy_debug_obj *o, VCL_ENUM e)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(o, VMOD_DEBUG_OBJ_MAGIC);
-	assert(!strcmp(e, "martin"));
+	assert(!vstrcmp(e, "martin"));
 }
 
 VCL_VOID v_matchproto_(td_xyzzy_obj_enum)

--- a/vmod/vmod_debug_transport_reembarking_http1.c
+++ b/vmod/vmod_debug_transport_reembarking_http1.c
@@ -170,7 +170,8 @@ dbg_sendbody(struct worker *wrk, void *arg)
 	CNT_Embark(wrk, req);
 	req->vdc->wrk = wrk;	// move to CNT_Embark?
 
-	chunked = http_GetHdr(req->resp, H_Transfer_Encoding, &p) && strcmp(p, "chunked") == 0;
+	chunked = http_GetHdr(req->resp, H_Transfer_Encoding, &p) &&
+	    vstrcmp(p, "chunked") == 0;
 	if (chunked)
 		V1L_Chunked(v1l);
 	err = VDP_DeliverObj(req->vdc, req->objcore);

--- a/vmod/vmod_debug_transport_vai.c
+++ b/vmod/vmod_debug_transport_vai.c
@@ -392,8 +392,8 @@ dbg_vai_notify_init(struct dbg_vai_notify *sn)
 {
 
 	INIT_OBJ(sn, DBG_VAI_NOTIFY_MAGIC);
-	AZ(pthread_mutex_init(&sn->mtx, NULL));
-	AZ(pthread_cond_init(&sn->cond, NULL));
+	PTOK(pthread_mutex_init(&sn->mtx, NULL));
+	PTOK(pthread_cond_init(&sn->cond, NULL));
 }
 
 static void
@@ -401,8 +401,8 @@ dbg_vai_notify_fini(struct dbg_vai_notify *sn)
 {
 
 	CHECK_OBJ_NOTNULL(sn, DBG_VAI_NOTIFY_MAGIC);
-	AZ(pthread_mutex_destroy(&sn->mtx));
-	AZ(pthread_cond_destroy(&sn->cond));
+	PTOK(pthread_mutex_destroy(&sn->mtx));
+	PTOK(pthread_cond_destroy(&sn->cond));
 }
 
 static void v_matchproto_(vai_notify_cb)
@@ -412,10 +412,10 @@ dbg_vai_notify(vai_hdl hdl, void *priv)
 
 	(void) hdl;
 	CAST_OBJ_NOTNULL(sn, priv, DBG_VAI_NOTIFY_MAGIC);
-	AZ(pthread_mutex_lock(&sn->mtx));
+	PTOK(pthread_mutex_lock(&sn->mtx));
 	sn->hasmore = 1;
-	AZ(pthread_cond_signal(&sn->cond));
-	AZ(pthread_mutex_unlock(&sn->mtx));
+	PTOK(pthread_cond_signal(&sn->cond));
+	PTOK(pthread_mutex_unlock(&sn->mtx));
 
 }
 
@@ -424,12 +424,12 @@ dbg_vai_notify_wait(struct dbg_vai_notify *sn)
 {
 
 	CHECK_OBJ_NOTNULL(sn, DBG_VAI_NOTIFY_MAGIC);
-	AZ(pthread_mutex_lock(&sn->mtx));
+	PTOK(pthread_mutex_lock(&sn->mtx));
 	while (sn->hasmore == 0)
-		AZ(pthread_cond_wait(&sn->cond, &sn->mtx));
+		PTOK(pthread_cond_wait(&sn->cond, &sn->mtx));
 	AN(sn->hasmore);
 	sn->hasmore = 0;
-	AZ(pthread_mutex_unlock(&sn->mtx));
+	PTOK(pthread_mutex_unlock(&sn->mtx));
 }
 
 static void

--- a/vmod/vmod_debug_transport_vai.c
+++ b/vmod/vmod_debug_transport_vai.c
@@ -363,7 +363,8 @@ dbg_vai_deliverobj(struct worker *wrk, void *arg)
 	CNT_Embark(wrk, req);
 	req->vdc->wrk = wrk;	// move to CNT_Embark?
 
-	chunked = http_GetHdr(req->resp, H_Transfer_Encoding, &p) && strcmp(p, "chunked") == 0;
+	chunked = http_GetHdr(req->resp, H_Transfer_Encoding, &p) &&
+	    vstrcmp(p, "chunked") == 0;
 	if (chunked)
 		V1L_Chunked(v1l);
 	err = VDP_DeliverObj(req->vdc, req->objcore);
@@ -468,7 +469,8 @@ dbg_vai_lease(struct worker *wrk, void *arg)
 	VSCARAB_LOCAL(scarab, cap);
 	VSCARET_LOCAL(scaret, cap);
 
-	chunked = http_GetHdr(req->resp, H_Transfer_Encoding, &p) && strcmp(p, "chunked") == 0;
+	chunked = http_GetHdr(req->resp, H_Transfer_Encoding, &p) &&
+	    vstrcmp(p, "chunked") == 0;
 	if (chunked)
 		V1L_Chunked(v1l);
 

--- a/vmod/vmod_debug_transport_vai.c
+++ b/vmod/vmod_debug_transport_vai.c
@@ -61,7 +61,7 @@ vdpio_hello_init(VRT_CTX, struct vdp_ctx *vdc, void **priv, int capacity)
 	if (*vdc->clen < 0)
 		return (capacity);
 
-	*vdc->clen += strlen(HELLO);
+	*vdc->clen += vstrlen(HELLO);
 	http_Unset(vdc->hp, H_Content_Length);
 	http_PrintfHeader(vdc->hp, "Content-Length: %jd", *vdc->clen);
 	return (capacity);
@@ -78,7 +78,7 @@ vdpio_hello_lease(struct vdp_ctx *vdc, struct vdp_entry *this,
 		return (0);
 	//lint -e{446} side effects in initializer - uh?
 	VSCARAB_ADD_IOV_NORET(scarab, ((struct iovec)
-	    {.iov_base = TRUST_ME(HELLO), .iov_len = strlen(HELLO)}));
+	    {.iov_base = TRUST_ME(HELLO), .iov_len = vstrlen(HELLO)}));
 	r = vdpio_pull(vdc, this, scarab);
 
 	(void) VDPIO_Close1(vdc, this);

--- a/vmod/vmod_directors_shard_cfg.c
+++ b/vmod/vmod_directors_shard_cfg.c
@@ -362,7 +362,7 @@ shardcfg_backend_cmp(const struct shard_backend *a,
 
 	AN(ai);
 	AN(bi);
-	return (strcmp(ai, bi));
+	return (vstrcmp(ai, bi));
 }
 
 /* for removal, we delete all instances if the backend matches */

--- a/vmod/vmod_std_fileread.c
+++ b/vmod/vmod_std_fileread.c
@@ -104,7 +104,7 @@ find_frfile(struct vmod_priv *priv, VCL_STRING file_name)
 
 	if (priv->priv != NULL) {
 		CAST_OBJ_NOTNULL(frf, priv->priv, CACHED_FILE_MAGIC);
-		if (!strcmp(file_name, frf->file_name))
+		if (!vstrcmp(file_name, frf->file_name))
 			return (frf);
 	}
 
@@ -112,7 +112,7 @@ find_frfile(struct vmod_priv *priv, VCL_STRING file_name)
 	if (frf != NULL)
 		frf->refcount--;
 	VTAILQ_FOREACH(frf, &frlist, list) {
-		if (!strcmp(file_name, frf->file_name)) {
+		if (!vstrcmp(file_name, frf->file_name)) {
 			frf->refcount++;
 			break;
 		}

--- a/vmod/vmod_vtc.c
+++ b/vmod/vmod_vtc.c
@@ -400,7 +400,7 @@ vsl_tagcmp(const void *aa, const void *bb)
 		return (-1);
 	else if (a->string == NULL && b->string == NULL)
 		return (0);
-	return (strcmp(a->string, b->string));
+	return (vstrcmp(a->string, b->string));
 }
 
 /*lint -esym(528, init_vsl_tag2enum) */


### PR DESCRIPTION
13 commits: a small standalone assert, a vtim.c parsing refactor, and
a batch of coccinelle-driven mechanical cleanups (check_obj.cocci,
closefd.cocci, printf_nofmt.cocci, pthread_errno.cocci,
vslb_single_string.cocci, vstrlen(), vstrcmp()).

Three needed adjustment to preserve this repo's own divergent code
instead of taking upstream's exact diff:
- `vtim: Keep track of parsing in a struct` kept strncmp() instead of
  upstream's memcmp() for weekday/month matching. At the time of that
  commit, upstream's memcmp() could overread past a short buffer (no
  boundary check) -- found later in
  https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/issues/4553 and
  fixed in https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4554
  (unmerged here as backport/4554-vtim-strncmp).
- `Use vstrlen()` kept that same strncmp() choice, plus this repo's
  downstream-only htc->oper write path in
  cache_backend_probe.c/cache_http2_session.c.
- `Use vstrcmp()` kept this repo's own downstream-only code in 4
  spots: an extra `-x parameter-json` mode in mgt_main.c, the
  varnishd/Varnish- naming already in place in mgt_util.c and
  vinylncsa.c, and cls_dispatch()'s caller-supplied cp/na calling
  convention in vcli_serve.c, which has diverged from upstream's
  internal-lookup version since before this repo's tracked commit
  history begins.

Upstream:
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/fb7f96c2585c6e26b92dd60e0351d3bb729cde0b
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/30892518187697d4c3685479508ec67c7cb8e50f
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/0d79691ca8123b38c9bd39b3a043113dd7ea3e49
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/b999cedd320b433597a66aa6af41da0fa5462078
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/47a7376d5f1ec52288a1aa1e8c473383d45a32ab
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/31e0ae461b6d046b90b338f1ffc00505e848d169
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/f7833daff6d44add542a1f06b53f6d4717f27662
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/46ae5a26992412e2eeebca0910f93d8146bebc48
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/3adc04335d11e17ee7b5a3b0ca646c154a0c9561
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/8b2f692eac91683761fcb53b333628324b9d0834
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/925c28bcc219ebd2d44361851b974468f5338a10
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/53c6f1ebba6bc49bd0eb89ed1a626dadf601b42b
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/c337cd642860217568783ee5de4fb780c30a4f02