### PR TITLE
v1f: Add readahead function, demo that readahead works (intermediate commit)

### DIFF
--- a/bin/vinyld/Makefile.am
+++ b/bin/vinyld/Makefile.am
@@ -234,6 +234,11 @@ vhp_decode_test_SOURCES = hpack/vhp_decode.c hpack/vhp_table.c
 vhp_decode_test_CFLAGS = -DDECODE_TEST_DRIVER
 vhp_decode_test_LDADD = $(top_builddir)/lib/libvinyl/libvarnish.la
 
+TESTS += http1_vfp_test
+http1_vfp_test_SOURCES = http1/cache_http1_vfp.c
+http1_vfp_test_CFLAGS = -DTEST_DRIVER
+http1_vfp_test_LDADD = $(top_builddir)/lib/libvinyl/libvarnish.la
+
 noinst_PROGRAMS += esi_parse_fuzzer
 esi_parse_fuzzer_SOURCES = \
 	cache/cache_ws_emu.c \

--- a/bin/vinyld/http1/cache_http1_vfp.c
+++ b/bin/vinyld/http1/cache_http1_vfp.c
@@ -119,7 +119,248 @@ v1f_rxbuf_read(const struct vfp_ctx *vc, struct http_conn *htc)
 
 #ifdef TEST_DRIVER
 
+/*--------------------------------------------------------------------
+ * Parse a chunk tail in the pipeline and return status as appropriate
+ */
+struct pct { const char *msg; };
+
+static struct pct pct_more[]	= {{"tail more"}};
+static struct pct pct_nonl[]	= {{"chunked tail no NL"}};
+
+// the unused parameter is to simplify the macro calling different parsers
+static struct pct *
+v1f_parse_chunked_tail(char *b, const char *e, void *unused, char **nextp)
+{
+	AN(b);
+	AN(e);
+	(void)unused;
+	AN(nextp);
+
+	if (b == e)
+		return (pct_more);
+	if (*b == '\r')
+		b++;
+	if (b == e)
+		return (pct_more);
+	if (*b != '\n')
+		return (pct_nonl);
+	b++;
+
+	*nextp = b;
+	return (NULL);
+}
+
+
+/*--------------------------------------------------------------------
+ * Parse a chunk header in the pipeline and return status as appropriate
+ */
+
+struct pch { const char *msg; };
+
+static struct pch pch_more[]	= {{"more"}};
+static struct pch pch_nonhex[]	= {{"chunked header non-hex"}};
+static struct pch pch_nonl[]	= {{"chunked header no NL"}};
+static struct pch pch_syntax[]	= {{"chunked header number syntax"}}; // can't happen?
+static struct pch pch_large[]	= {{"bogusly large chunk size"}};
+
+static struct pch *
+v1f_parse_chunked_hdr(char *b, const char *e, ssize_t *szp, char **nextp)
+{
+	char *hb, *he, *q, s;
+	uintmax_t cll;
+	ssize_t cl;
+
+	AN(b);
+	AN(e);
+	AN(szp);
+	AN(nextp);
+
+	/* Skip leading whitespace */
+	while (b < e && vct_isows(*b))
+		b++;
+	if (b == e)
+		return (pch_more);
+	if (!vct_ishex(*b))
+		return (pch_nonhex);
+	/* Skip leading zeros */
+	while (b < e - 1 && b[0] == '0' && b[1] == '0')
+		b++;
+	if (b == e)
+		return (pch_more);
+	hb = b;
+	/* Collect hex digits */
+	while (b < e && vct_ishex(*b))
+		b++;
+	if (b == e)
+		return (pch_more);
+	he = b;
+	/* Skip trailing whitespace.
+	 * XXX extension support missing https://httpwg.org/specs/rfc9112.html#chunked.extension
+	 */
+	while (b < e && vct_isows(*b))
+		b++;
+	if (b == e)
+		return (pch_more);
+	if (*b == '\r')
+		b++;
+	if (b == e)
+		return (pch_more);
+	if (*b != '\n')
+		return (pch_nonl);
+	b++;
+
+	errno = 0;
+	s = *he;
+	*he = '\0';
+	cll = strtoumax(hb, &q, 16);
+	// restore original for debug-/testability
+	*he = s;
+
+	if (q == NULL || q != he)
+		return (pch_syntax);
+
+	cl = (ssize_t)cll;
+	if (cl < 0 || (uintmax_t)cl != cll)
+		return (pch_large);
+
+	// for a number larger than ULLONG_MAX, strtoumax() returns
+	// ULLONG_MAX and sets errno to ERANGE. We catch this with the above
+	// check already, but assert that we really do
+	AZ(errno);
+
+	*szp = cl;
+	*nextp = b;
+	return (NULL);
+}
+
+#include <stdlib.h>
 #include <stdio.h>
+
+// positive test cases have three constituents, we permutate all of them
+static const char *t_ok_pre[] = {
+	"",
+	" ",
+	"\t",
+	" \t0",
+	"00"
+};
+
+static const uintmax_t t_ok_sz[] = {
+	0,
+	1,
+	0xa,
+	0x10,
+	0xaffe,
+	SSIZE_MAX
+};
+
+static const char *t_ok_post[] = {
+	"\r\n",
+	"\n",
+	" \r\n",
+	" \t\n",
+};
+
+static const char *t_ok_next[] = {
+	"",
+	"\r\n",
+	"\n",
+	"GET",
+	"\r\n01234567",
+};
+
+struct pch_neg {
+	struct pch *r;
+	const char *hdr;
+};
+
+// negative tests
+static struct pch_neg t_neg[] = {
+	{pch_more, ""},
+	{pch_more, "\t "},
+
+	{pch_nonhex, "x"},
+	{pch_nonhex, " x"},
+	{pch_nonhex, "\n"},
+	{pch_nonhex, "\r"},
+
+	{pch_more, "000"},
+	{pch_more, "affe"},
+	{pch_more, " a\r"},
+
+	{pch_nonl, " a\rx"},
+	{pch_nonl, " ax"},
+
+	{pch_large, "8000000000000000\r\n"},
+	{pch_large, "800000000000000000000000\r\n"},
+};
+
+// tail
+static const char *t_ok_tail[] = {
+	"\r\n",
+	"\n",
+};
+
+static const char *t_ok_tail_next[] = {
+	"",
+	"0123",
+};
+
+struct pct_neg {
+	struct pct *r;
+	const char *hdr;
+};
+
+static struct pct_neg t_neg_tail[] = {
+	{pct_more, "\r"},
+	{pct_nonl, "\rx"},
+};
+
+
+static void
+t_parse_chunked_hdr(char *b, char *e,
+    const struct pch *r_exp, ssize_t sz_exp, const char *next_exp)
+{
+	const struct pch *r;
+	char *next = NULL;
+	ssize_t sz = -1;
+	r = v1f_parse_chunked_hdr(b, e, &sz, &next);
+#ifdef DEBUG
+	printf("r = %s, sz = 0x%zx, n = %s\n", r ? r->msg : "NULL", sz,
+	    next ? next : "NULL");
+#endif
+	assert(r == r_exp);
+	assert(sz == sz_exp);
+	assert(next == next_exp);
+}
+
+static void
+t_parse_chunked_hdr_err(char *b, char *e, const struct pch *err)
+{
+	t_parse_chunked_hdr(b, e, err, -1, NULL);
+}
+
+static void
+t_parse_chunked_hdr_ok(char *b, char *e,
+    ssize_t sz_exp, const char *next_exp)
+{
+	t_parse_chunked_hdr(b, e, NULL, sz_exp, next_exp);
+}
+
+static void
+t_parse_chunked_tail(char *b, char *e,
+    const struct pct *r_exp, const char *next_exp)
+{
+	const struct pct *r;
+	char *next = NULL;
+	r = v1f_parse_chunked_tail(b, e, NULL, &next);
+#ifdef DEBUG
+	printf("r = %s, n = %s\n", r ? r->msg : "NULL",
+	    next ? next : "NULL");
+#endif
+	assert(r == r_exp);
+	assert(next == next_exp);
+}
 
 void
 VSLbs(struct vsl_log *vsl, enum VSL_tag_e tag, const struct strands *s)
@@ -201,6 +442,73 @@ main(int argc, char *argv[])
 
 	printf("-- rxbuf_read\n");
 	t_rxbuf_read();
+
+	printf("-- head postitive test permutations\n");
+	// avoid nested loops
+	unsigned n_ok = vcountof(t_ok_pre) * vcountof(t_ok_sz) *
+	    vcountof(t_ok_post) * vcountof(t_ok_next);
+	char buf[80];
+	for (unsigned n = 0; n < n_ok; n++) {
+		unsigned n_pre = n % vcountof(t_ok_pre);
+		unsigned n_sz = n / vcountof(t_ok_pre);
+		unsigned n_post = n_sz / vcountof(t_ok_sz);
+		unsigned n_next = n_post / vcountof(t_ok_post);
+		n_sz %= vcountof(t_ok_sz);
+		n_post %= vcountof(t_ok_post);
+		assert(n_next < vcountof(t_ok_next));
+
+#ifdef DEBUG
+		printf("n_next=%u n_post=%u n_sz=%u n_pre=%u\n",
+		    n_next, n_post, n_sz, n_pre);
+#endif
+		bprintf(buf, "%s%jx%s%s", t_ok_pre[n_pre], t_ok_sz[n_sz],
+		    t_ok_post[n_post], t_ok_next[n_next]);
+
+		char *ee = buf + strlen(buf) - strlen(t_ok_next[n_next]);
+
+		for (char *e = buf; e < ee; e++)
+			t_parse_chunked_hdr_err(buf, e, pch_more);
+
+		t_parse_chunked_hdr_ok(buf, ee, t_ok_sz[n_sz], ee);
+	}
+
+	printf("-- head negative tests\n");
+	for (struct pch_neg *neg = t_neg; neg < t_neg + vcountof(t_neg); neg++) {
+		size_t l = strlen(neg->hdr);
+		assert(l < sizeof buf);
+
+		memcpy(buf, neg->hdr, l + 1);
+		char *e = buf + l;
+
+		t_parse_chunked_hdr_err(buf, e, neg->r);
+	}
+
+	printf("-- tail postitive test permutations\n");
+	n_ok = vcountof(t_ok_tail) * vcountof(t_ok_tail_next);
+	for (unsigned n = 0; n < n_ok; n++) {
+		unsigned n_tail = n % vcountof(t_ok_tail);
+		unsigned n_next = n / vcountof(t_ok_tail_next);
+		assert(n_next < vcountof(t_ok_tail_next));
+
+		bprintf(buf, "%s%s", t_ok_tail[n_tail], t_ok_tail_next[n_next]);
+		char *ee = buf + strlen(buf) - strlen(t_ok_tail_next[n_next]);
+
+		for (char *e = buf; e < ee; e++)
+			t_parse_chunked_tail(buf, e, pct_more, NULL);
+
+		t_parse_chunked_tail(buf, ee, NULL, ee);
+	}
+
+	printf("-- tail negative tests\n");
+	for (struct pct_neg *neg = t_neg_tail; neg < t_neg_tail + vcountof(t_neg_tail); neg++) {
+		size_t l = strlen(neg->hdr);
+		assert(l < sizeof buf);
+
+		memcpy(buf, neg->hdr, l + 1);
+		char *e = buf + l;
+
+		t_parse_chunked_tail(buf, e, neg->r, NULL);
+	}
 
 	printf("OK\n");
 	return (0);

--- a/bin/vinyld/http1/cache_http1_vfp.c
+++ b/bin/vinyld/http1/cache_http1_vfp.c
@@ -48,8 +48,9 @@
 #include "vct.h"
 #include "vtcp.h"
 
+static const unsigned max_chunked_hdr = 32;	// adjust b00007.vtc if changed
+
 #ifndef TEST_DRIVER
-static const unsigned max_chunked_hdr = 32;
 static ssize_t
 v1f_rxbuf_init(struct http_conn *htc)
 {
@@ -70,7 +71,7 @@ v1f_rxbuf_init(struct http_conn *htc)
  * continue reading after it
  */
 static ssize_t
-v1f_rxbuf_read(const struct vfp_ctx *vc, struct http_conn *htc)
+v1f_rxbuf_read(struct http_conn *htc)
 {
 	ssize_t i;
 	size_t sz;
@@ -90,8 +91,11 @@ v1f_rxbuf_read(const struct vfp_ctx *vc, struct http_conn *htc)
 	else {
 		AN(htc->pipeline_e);
 		i = pdiff(htc->pipeline_b, htc->pipeline_e);
-		if (i == sz)
-			return (0);
+		if (i >= sz) {
+			// VTCP_Check(): can not originate from read()
+			errno = ENOBUFS;
+			return (-1);
+		}
 		assert(i >= 0);
 		assert((size_t)i < sz);
 		memmove(htc->rxbuf_b, htc->pipeline_b, i);
@@ -100,15 +104,12 @@ v1f_rxbuf_read(const struct vfp_ctx *vc, struct http_conn *htc)
 		p = htc->pipeline_e;
 		sz -= i;
 	}
-
 	do {
 		errno = 0;
 		i = htc->oper->read(htc->oper_priv, *htc->rfd, p, sz);
 	} while (i < 0 && errno == EINTR);
 	if (i < 0) {
 		VCO_Assert(htc->oper, i);
-		VSLbs(vc->wrk->vsl, SLT_FetchError,
-		    TOSTRAND(VAS_errtxt(errno)));
 		return (i);
 	}
 	htc->pipeline_e = p + i;
@@ -116,8 +117,6 @@ v1f_rxbuf_read(const struct vfp_ctx *vc, struct http_conn *htc)
 		 htc->pipeline_b = htc->pipeline_e = NULL;
 	return (i);
 }
-
-#ifdef TEST_DRIVER
 
 /*--------------------------------------------------------------------
  * Parse a chunk tail in the pipeline and return status as appropriate
@@ -162,9 +161,10 @@ static struct pch pch_nonhex[]	= {{"chunked header non-hex"}};
 static struct pch pch_nonl[]	= {{"chunked header no NL"}};
 static struct pch pch_syntax[]	= {{"chunked header number syntax"}}; // can't happen?
 static struct pch pch_large[]	= {{"bogusly large chunk size"}};
+static struct pch pch_toolong[]	= {{"chunked header too long"}};
 
 static struct pch *
-v1f_parse_chunked_hdr(char *b, const char *e, ssize_t *szp, char **nextp)
+v1f_parse_chunked_hdr_i(char *b, const char *e, ssize_t *szp, char **nextp)
 {
 	char *hb, *he, *q, s;
 	uintmax_t cll;
@@ -232,6 +232,25 @@ v1f_parse_chunked_hdr(char *b, const char *e, ssize_t *szp, char **nextp)
 	*nextp = b;
 	return (NULL);
 }
+
+// length check outside the actual parser for clarity
+static struct pch *
+v1f_parse_chunked_hdr(char *b, const char *e, ssize_t *szp, char **nextp)
+{
+	static struct pch *r;
+	const char *ee;
+
+	ee = vmin_t(const char *, e, b + max_chunked_hdr);
+
+	r = v1f_parse_chunked_hdr_i(b, ee, szp, nextp);
+
+	if (r == pch_more && e != ee)
+		return (pch_toolong);
+
+	return (r);
+}
+
+#ifdef TEST_DRIVER
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -390,7 +409,7 @@ static const struct vco t_vco = {
 
 /*
 static ssize_t
-v1f_rxbuf_read(const struct vfp_ctx *vc, struct http_conn *htc);
+v1f_rxbuf_read(struct http_conn *htc);
 */
 static void
 t_rxbuf_read(void) {
@@ -413,7 +432,7 @@ t_rxbuf_read(void) {
 	for (i = 0; i < strlen(data); i++) {
 		r = write(fd[1], data + i, 1);
 		assert(r == 1);
-		r = v1f_rxbuf_read(NULL, htc);
+		r = v1f_rxbuf_read(htc);
 		assert(r == 1);
 		size_t av = pdiff(htc->pipeline_b, htc->pipeline_e);
 		assert(av == i + 1);
@@ -428,7 +447,9 @@ t_rxbuf_read(void) {
 
 	}
 	// buffer is now full
-	AZ(v1f_rxbuf_read(NULL, htc));
+	r = v1f_rxbuf_read(htc);
+	assert(r == -1);
+	assert(errno == ENOBUFS);
 
 	close(fd[0]);
 	close(fd[1]);
@@ -531,19 +552,6 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 	assert(len > 0);
 	l = 0;
 	p = d;
-	// XXX temp v1f_chunked_hdr caller signal
-	if (len == 1 && htc->pipeline_b == NULL && htc->rxbuf_b == NULL) {
-		i = v1f_rxbuf_init(htc);
-		if (i) {
-			VSLb(vc->wrk->vsl, SLT_FetchError, "No workspace for rxbuf");
-			return (i);
-		}
-	}
-	if (len == 1 && htc->pipeline_b == NULL && htc->rxbuf_b != NULL) {
-		i = v1f_rxbuf_read(vc, htc);
-		if (i < 0)
-			return (i);
-	}
 	i = 0;
 	if (htc->pipeline_b) {
 		l = htc->pipeline_e - htc->pipeline_b;
@@ -576,94 +584,79 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 	return (i + l);
 }
 
-
-/*--------------------------------------------------------------------
- * read (CR)?LF at the end of a chunk
- */
 static enum vfp_status
-v1f_chunk_end(struct vfp_ctx *vc, struct http_conn *htc)
+v1f_ok(struct http_conn *htc)
 {
-	char c;
-
-	if (v1f_read(vc, htc, &c, 1) <= 0)
-		return (VFP_Error(vc, "chunked read err"));
-	if (c == '\r' && v1f_read(vc, htc, &c, 1) <= 0)
-		return (VFP_Error(vc, "chunked read err"));
-	if (c != '\n')
-		return (VFP_Error(vc, "chunked tail no NL"));
+	if ((htc)->pipeline_b == (htc)->pipeline_e)
+		(htc)->pipeline_b = (htc)->pipeline_e = NULL;
 	return (VFP_OK);
 }
 
 
 /*--------------------------------------------------------------------
- * Parse a chunk header and, for VFP_OK, return size in a pointer
+ * Call parser on pipeline:
+ * - If pipeline filled, try to return a parse result without reading
+ * - else read until either the rxbuf is filled, or we have a parse
  *
- * XXX: Reading one byte at a time is pretty pessimal.
+ * this is a macro because the code for calling the head and tail parser is
+ * _almost_ (but not quite) identical
+ */
+
+#define CHUNKED_PARSER(vc, htc, func, func_arg, more, what)			\
+										\
+	ssize_t sz;								\
+										\
+	if ((htc)->pipeline_b) {						\
+		r = func((htc)->pipeline_b, (htc)->pipeline_e,			\
+			func_arg, &(htc)->pipeline_b);				\
+		if (r == NULL)							\
+			return (v1f_ok(htc));					\
+		if (r != more)							\
+			return (VFP_Error(vc, "%s", r->msg));			\
+	}									\
+	if ((htc)->rxbuf_b == NULL && v1f_rxbuf_init(htc) != 0)			\
+		return (VFP_Error(vc, "No workspace for rxbuf"));		\
+	while ((sz = v1f_rxbuf_read(htc)) > 0) {				\
+		r = func((htc)->pipeline_b, (htc)->pipeline_e,			\
+		    func_arg, &(htc)->pipeline_b);				\
+		if (r == NULL)							\
+			return (v1f_ok(htc));					\
+		if (r == more)							\
+			continue;						\
+		VSLb((vc)->wrk->vsl, SLT_Debug, "%.*s",				\
+		    (int)pdiff((htc)->pipeline_b, (htc)->pipeline_e),		\
+		    (htc)->pipeline_b);						\
+		return (VFP_Error(vc, "%s", r->msg));				\
+	}									\
+	if (sz == 0)								\
+		return (VFP_Error(vc, "chunked " what " EOF"));			\
+	assert(sz < 0);								\
+	VSLbs(vc->wrk->vsl, SLT_FetchError, TOSTRAND(VAS_errtxt(errno)));	\
+	return (VFP_Error(vc, "^^^ error reading chunk " what));
+
+/*--------------------------------------------------------------------
+ * read (CR)?LF at the end of a chunk
+ */
+
+static enum vfp_status
+v1f_chunk_end(struct vfp_ctx *vc, struct http_conn *htc)
+{
+	const struct pct *r;
+	CHUNKED_PARSER(vc, htc, v1f_parse_chunked_tail, NULL, pct_more, "tail")
+}
+
+/*--------------------------------------------------------------------
+ * Parse a chunk header and, for VFP_OK, return size in a pointer
  */
 
 static enum vfp_status
 v1f_chunked_hdr(struct vfp_ctx *vc, struct http_conn *htc, ssize_t *szp)
 {
-	char buf[20];		/* XXX: 20 is arbitrary */
-	unsigned u;
-	uintmax_t cll;
-	ssize_t cl, lr;
-	char *q;
-
-	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
-	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
-	AN(szp);
-	assert(*szp == -1);
-
-	/* Skip leading whitespace */
-	do {
-		lr = v1f_read(vc, htc, buf, 1);
-		if (lr <= 0)
-			return (VFP_Error(vc, "chunked read err"));
-	} while (vct_isows(buf[0]));
-
-	if (!vct_ishex(buf[0]))
-		return (VFP_Error(vc, "chunked header non-hex"));
-
-	/* Collect hex digits, skipping leading zeros */
-	for (u = 1; u < sizeof buf; u++) {
-		do {
-			lr = v1f_read(vc, htc, buf + u, 1);
-			if (lr <= 0)
-				return (VFP_Error(vc, "chunked read err"));
-		} while (u == 1 && buf[0] == '0' && buf[u] == '0');
-		if (!vct_ishex(buf[u]))
-			break;
-	}
-
-	if (u >= sizeof buf)
-		return (VFP_Error(vc, "chunked header too long"));
-
-	/* Skip trailing white space */
-	while (vct_isows(buf[u])) {
-		lr = v1f_read(vc, htc, buf + u, 1);
-		if (lr <= 0)
-			return (VFP_Error(vc, "chunked read err"));
-	}
-
-	if (buf[u] == '\r' && v1f_read(vc, htc, buf + u, 1) <= 0)
-		return (VFP_Error(vc, "chunked read err"));
-	if (buf[u] != '\n')
-		return (VFP_Error(vc, "chunked header no NL"));
-
-	buf[u] = '\0';
-
-	cll = strtoumax(buf, &q, 16);
-	if (q == NULL || *q != '\0')
-		return (VFP_Error(vc, "chunked header number syntax"));
-	cl = (ssize_t)cll;
-	if (cl < 0 || (uintmax_t)cl != cll)
-		return (VFP_Error(vc, "bogusly large chunk size"));
-
-	*szp = cl;
-	return (VFP_OK);
+	const struct pch *r;
+	CHUNKED_PARSER(vc, htc, v1f_parse_chunked_hdr, szp, pch_more, "header")
 }
 
+#undef CHUNKED_PARSER
 
 /*--------------------------------------------------------------------
  * Check if data is available

--- a/bin/vinyld/http1/cache_http1_vfp.c
+++ b/bin/vinyld/http1/cache_http1_vfp.c
@@ -175,7 +175,7 @@ v1f_parse_chunked_hdr_i(char *b, const char *e, ssize_t *szp, char **nextp)
 	AN(szp);
 	AN(nextp);
 
-	/* Skip leading whitespace */
+	/* Skip leading whitespace - XXX rfc9112 does not specify this */
 	while (b < e && vct_isows(*b))
 		b++;
 	if (b == e)
@@ -194,7 +194,7 @@ v1f_parse_chunked_hdr_i(char *b, const char *e, ssize_t *szp, char **nextp)
 	if (b == e)
 		return (pch_more);
 	he = b;
-	/* Skip trailing whitespace.
+	/* Skip trailing whitespace. XXX rfc9112 does not specify this
 	 * XXX extension support missing https://httpwg.org/specs/rfc9112.html#chunked.extension
 	 */
 	while (b < e && vct_isows(*b))

--- a/bin/vinyld/http1/cache_http1_vfp.c
+++ b/bin/vinyld/http1/cache_http1_vfp.c
@@ -540,8 +540,42 @@ main(int argc, char *argv[])
  * Read up to len bytes, returning pipelined data first.
  */
 
+enum ahead {
+	NO_READ_AHEAD,
+	READ_AHEAD
+};
+
 static ssize_t
-v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
+v1f_readahead(struct http_conn *htc, unsigned char *p, ssize_t len)
+{
+	struct iovec iov[2];
+	ssize_t i;
+
+	AZ(htc->pipeline_b);
+	if (htc->rxbuf_b == NULL && v1f_rxbuf_init(htc)) {
+		errno = ENOMEM;
+		return (-ENOMEM);
+	}
+	AN(htc->rxbuf_b);
+
+	iov[0].iov_base = p;
+	iov[0].iov_len = len;
+	iov[1].iov_base = htc->rxbuf_b;
+	iov[1].iov_len = pdiff(htc->rxbuf_b, htc->rxbuf_e);
+
+	i = readv(*htc->rfd, iov, vcountof(iov));
+	if (i <= len)
+		return (i);
+	i -= len;
+	htc->pipeline_b = htc->rxbuf_b;
+	htc->pipeline_e = htc->rxbuf_b + i;
+
+	return (len);
+}
+
+static ssize_t
+v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len,
+    enum ahead ahead)
 {
 	ssize_t l;
 	unsigned char *p;
@@ -567,10 +601,15 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 	if (len > 0) {
 		do {
 			errno = 0;
-			i = htc->oper->read(htc->oper_priv, *htc->rfd, p, len);
+			if (ahead == READ_AHEAD && htc->oper == VCO_default)
+				i = v1f_readahead(htc, p, len);
+			else
+				i = htc->oper->read(htc->oper_priv, *htc->rfd, p, len);
 		} while (i < 0 && errno == EINTR);
 		if (i < 0) {
-			VCO_Assert(htc->oper, i);
+			if (ahead == NO_READ_AHEAD || htc->oper != VCO_default ||
+			    i != -ENOMEM)
+				VCO_Assert(htc->oper, i);
 			VSLbs(vc->wrk->vsl, SLT_FetchError,
 			    TOSTRAND(VAS_errtxt(errno)));
 			return (i);
@@ -659,37 +698,6 @@ v1f_chunked_hdr(struct vfp_ctx *vc, struct http_conn *htc, ssize_t *szp)
 #undef CHUNKED_PARSER
 
 /*--------------------------------------------------------------------
- * Check if data is available
- */
-
-static int
-v1f_poll(const struct http_conn *htc)
-{
-	struct pollfd pfd[1];
-	int r;
-
-	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
-
-	if (htc->pipeline_b)
-		return (1);
-
-	pfd->fd = *htc->rfd;
-	pfd->events = POLLIN;
-
-	r = poll(pfd, 1, 0);
-	if (r < 0) {
-		assert(errno == EINTR);
-		return (0);
-	}
-	if (r == 0)
-		return (0);
-	assert(r == 1);
-	assert(pfd->revents & POLLIN);
-	return (1);
-}
-
-
-/*--------------------------------------------------------------------
  * Read a chunked HTTP object.
  *
  */
@@ -716,9 +724,11 @@ v1f_chunked_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 			return (vfps);
 	}
 	if (vfe->priv2 > 0) {
-		if (vfe->priv2 < l)
+		if (vfe->priv2 <= l) {
 			l = vfe->priv2;
-		lr = v1f_read(vc, htc, ptr, l);
+			lr = v1f_read(vc, htc, ptr, l, READ_AHEAD);
+		} else
+			lr = v1f_read(vc, htc, ptr, l, NO_READ_AHEAD);
 		if (lr <= 0)
 			return (VFP_Error(vc, "chunked insufficient bytes"));
 		*lp = lr;
@@ -732,13 +742,17 @@ v1f_chunked_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 		if (vfps != VFP_OK)
 			return (vfps);
 
-		/* only if some data of the next chunk header is available, read
-		 * it to check if we can return VFP_END */
-		if (! v1f_poll(htc))
+		/* opportunistically check for next chunk header read ahead */
+		if (! htc->pipeline_b)
 			return (VFP_OK);
-		vfps = v1f_chunked_hdr(vc, htc, &vfe->priv2);
-		if (vfps != VFP_OK)
-			return (vfps);
+
+		const struct pch *r = v1f_parse_chunked_hdr(
+		    htc->pipeline_b, htc->pipeline_e,
+		    &vfe->priv2, &htc->pipeline_b);
+		if (r == pch_more)
+			return (VFP_OK);
+		if (r != NULL)
+			return (VFP_Error(vc, "%s", r->msg));
 		if (vfe->priv2 != 0)
 			return (VFP_OK);
 	}
@@ -774,7 +788,7 @@ v1f_straight_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 	if (vfe->priv2 == 0) // XXX: Optimize Content-Len: 0 out earlier
 		return (VFP_END);
 	l = vmin(l, vfe->priv2);
-	lr = v1f_read(vc, htc, p, l);
+	lr = v1f_read(vc, htc, p, l, NO_READ_AHEAD);
 	if (lr <= 0)
 		return (VFP_Error(vc, "straight insufficient bytes"));
 	*lp = lr;
@@ -806,7 +820,7 @@ v1f_eof_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p, ssize_t *lp)
 
 	l = *lp;
 	*lp = 0;
-	lr = v1f_read(vc, htc, p, l);
+	lr = v1f_read(vc, htc, p, l, NO_READ_AHEAD);
 	if (lr < 0)
 		return (VFP_Error(vc, "eof socket fail"));
 	if (lr == 0) {

--- a/bin/vinyld/http1/cache_http1_vfp.c
+++ b/bin/vinyld/http1/cache_http1_vfp.c
@@ -48,6 +48,165 @@
 #include "vct.h"
 #include "vtcp.h"
 
+#ifndef TEST_DRIVER
+static const unsigned max_chunked_hdr = 32;
+static ssize_t
+v1f_rxbuf_init(struct http_conn *htc)
+{
+
+	AZ(htc->rxbuf_b);
+	AZ(htc->rxbuf_e);
+
+	htc->rxbuf_b = WS_Alloc(htc->ws, max_chunked_hdr);
+	if (htc->rxbuf_b == NULL)
+		return (-1);
+	htc->rxbuf_e = htc->rxbuf_b + max_chunked_hdr;
+	return (0);
+}
+#endif
+
+/*
+ * fill up rxbuf. If there is pipelined data, move it to the beginning and
+ * continue reading after it
+ */
+static ssize_t
+v1f_rxbuf_read(const struct vfp_ctx *vc, struct http_conn *htc)
+{
+	ssize_t i;
+	size_t sz;
+	char *p;
+
+	if (htc->pipeline_b)
+		AN(htc->pipeline_e);
+	else
+		AZ(htc->pipeline_e);
+	AN(htc->rxbuf_b);
+	AN(htc->rxbuf_e);
+
+	sz = pdiff(htc->rxbuf_b, htc->rxbuf_e);
+
+	if (htc->pipeline_b == NULL)
+		p = htc->pipeline_b = htc->rxbuf_b;
+	else {
+		AN(htc->pipeline_e);
+		i = pdiff(htc->pipeline_b, htc->pipeline_e);
+		if (i == sz)
+			return (0);
+		assert(i >= 0);
+		assert((size_t)i < sz);
+		memmove(htc->rxbuf_b, htc->pipeline_b, i);
+		htc->pipeline_b = htc->rxbuf_b;
+		htc->pipeline_e = htc->rxbuf_b + i;
+		p = htc->pipeline_e;
+		sz -= i;
+	}
+
+	do {
+		errno = 0;
+		i = htc->oper->read(htc->oper_priv, *htc->rfd, p, sz);
+	} while (i < 0 && errno == EINTR);
+	if (i < 0) {
+		VCO_Assert(htc->oper, i);
+		VSLbs(vc->wrk->vsl, SLT_FetchError,
+		    TOSTRAND(VAS_errtxt(errno)));
+		return (i);
+	}
+	htc->pipeline_e = p + i;
+	if (htc->pipeline_b == htc->pipeline_e)
+		 htc->pipeline_b = htc->pipeline_e = NULL;
+	return (i);
+}
+
+#ifdef TEST_DRIVER
+
+#include <stdio.h>
+
+void
+VSLbs(struct vsl_log *vsl, enum VSL_tag_e tag, const struct strands *s)
+{
+	(void)vsl;
+	(void)tag;
+	(void)s;
+}
+
+static ssize_t
+t_vco_read(void *priv, int fd, void *buf, size_t len)
+{
+	(void)priv;
+	return (read(fd, buf, len));
+}
+
+static int
+t_vco_check(ssize_t a)
+{
+	return (a >= 0);
+}
+
+static const struct vco t_vco = {
+	.read = t_vco_read,
+	.check = t_vco_check,
+};
+
+/*
+static ssize_t
+v1f_rxbuf_read(const struct vfp_ctx *vc, struct http_conn *htc);
+*/
+static void
+t_rxbuf_read(void) {
+	struct http_conn htc[1];
+	const char *data = "0123456789abcdef";
+	char rxbuf[16];
+	int fd[2], i, r;
+
+	assert(strlen(data) == sizeof rxbuf);
+
+	INIT_OBJ(htc, HTTP_CONN_MAGIC);
+	// v1f_rxbuf_init without the workspace
+	htc->rxbuf_b = rxbuf;
+	htc->rxbuf_e = htc->rxbuf_b + sizeof rxbuf;
+	htc->oper = &t_vco;
+
+	AZ(pipe(fd));
+	htc->rfd = &fd[0];
+
+	for (i = 0; i < strlen(data); i++) {
+		r = write(fd[1], data + i, 1);
+		assert(r == 1);
+		r = v1f_rxbuf_read(NULL, htc);
+		assert(r == 1);
+		size_t av = pdiff(htc->pipeline_b, htc->pipeline_e);
+		assert(av == i + 1);
+		AZ(memcmp(htc->pipeline_b, data, av));
+		if (i % 2 == 0) {
+			// v1f_rxbuf_read moves pipelined data to the beginning
+			assert(htc->pipeline_b == htc->rxbuf_b);
+			memmove(htc->pipeline_b + 1, htc->pipeline_b, av);
+			htc->pipeline_b++;
+			htc->pipeline_e++;
+		}
+
+	}
+	// buffer is now full
+	AZ(v1f_rxbuf_read(NULL, htc));
+
+	close(fd[0]);
+	close(fd[1]);
+}
+
+int
+main(int argc, char *argv[])
+{
+	(void) argc;
+	(void) argv;
+
+	printf("-- rxbuf_read\n");
+	t_rxbuf_read();
+
+	printf("OK\n");
+	return (0);
+}
+#else
+
 /*--------------------------------------------------------------------
  * Read up to len bytes, returning pipelined data first.
  */
@@ -57,13 +216,27 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 {
 	ssize_t l;
 	unsigned char *p;
-	ssize_t i = 0;
+	ssize_t i;
 
 	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
 	assert(len > 0);
 	l = 0;
 	p = d;
+	// XXX temp v1f_chunked_hdr caller signal
+	if (len == 1 && htc->pipeline_b == NULL && htc->rxbuf_b == NULL) {
+		i = v1f_rxbuf_init(htc);
+		if (i) {
+			VSLb(vc->wrk->vsl, SLT_FetchError, "No workspace for rxbuf");
+			return (i);
+		}
+	}
+	if (len == 1 && htc->pipeline_b == NULL && htc->rxbuf_b != NULL) {
+		i = v1f_rxbuf_read(vc, htc);
+		if (i < 0)
+			return (i);
+	}
+	i = 0;
 	if (htc->pipeline_b) {
 		l = htc->pipeline_e - htc->pipeline_b;
 		assert(l > 0);
@@ -389,3 +562,4 @@ V1F_Setup_Fetch(struct vfp_ctx *vfc, struct http_conn *htc)
 	vfe->priv1 = htc;
 	return (0);
 }
+#endif

--- a/bin/vinyltest/tests/b00007.vtc
+++ b/bin/vinyltest/tests/b00007.vtc
@@ -18,9 +18,46 @@ server s1 {
 	send "00000004\r\n1234\r\n"
 	chunked "1234"
 	chunked ""
+
+	# read ahead of exactly 32 bytes chunked header (see v1f_rxbuf_init)
+	rxreq
+	expect req.url == "/32_1st"
+	send "HTTP/1.1 200 OK\r\nTransfer-encoding: chunked\r\n\r\n0000000000000000000000000000004\n1234\n"
+	chunkedlen 0
+
+	rxreq
+	expect req.url == "/32_2nd"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	chunkedlen 32768
+	send "0000000000000000000000000000004\n1234\n"
+	chunkedlen 0
+
+	# overlong chunk header read ahead after headers
+	rxreq
+	expect req.url == "/bazz"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	send "00000000000000000000000000000000000004"
+
+	accept
+	# overlong chunk header after first chunk
+	rxreq
+	expect req.url == "/bazz2"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	chunkedlen 32768
+	send "00000000000000000000000000000000000004"
 } -start
 
-varnish v1 -vcl+backend {} -start
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.do_stream = false;
+	}
+} -start
 
 client c1 {
 	txreq -url "/bar"
@@ -31,4 +68,20 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 	expect resp.bodylen == "8"
+	txreq -url "/32_1st"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == "4"
+	txreq -url "/32_2nd"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == "32772"
+
+	txreq -url "/bazz"
+	rxresp
+	expect resp.status == 503
+
+	txreq -url "/bazz2"
+	rxresp
+	expect resp.status == 503
 } -run


### PR DESCRIPTION
Backport of [vinyl-cache#4508](https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/pulls/4508), "Optimize fetch of HTTP/1.1 chunked bodies":

This is the continuation of vinyl-cache#3809 after the important realization that we do not need to worry about "overreading" into the next request, which dramatically simplifies the implementation and improves its efficiency:

- For client requests, we support pipelining, so we need to stash away overread bytes, but other than that have all the infrastructure already in place
- For backend responses, we do not need to worry about overreading, because we never pipeline backend requests, so there cannot be another response pending after the end of the current response

This patch series implements the obvious optimizations based on these insights:

1. `v1f: Add readahead function, demo that readahead works (intermediate commit)` -- demonstrates that we already have the proper handling in place to add pipeline data on the client side: it adds a read-ahead into a workspace-allocated receive buffer without changing any other code
2. `v1f: Add chunked head / tail parsers` -- adds chunked head and tail parsers, acting on a (potentially partial) buffer. Large diff, but mostly due to the exhaustive tests added
3. `v1f: Switch to reading all of chunked head/tail in one go` -- switches to the new paradigm: get pipeline data, try to parse it, read and repeat if incomplete
4. `v1f: Read ahead to have the next chunk header ready after a chunk` -- improves read ahead by using a vectored read into storage and the rxbuf for chunked header parsing whenever the chunk isn't larger than storage
5. `v1f: Take note where we are more postel than the rfc specifies`

Two real gaps found and fixed along the way, both because this repo's downstream-only `htc->oper` read abstraction (used by TLS client and TLS backend connections) isn't something upstream has to route through:
- `v1f_readahead()` uses raw `readv()` with no `oper` equivalent available, so it's only invoked when `htc->oper == VCO_default`; any other oper (e.g. TLS) falls back to the regular `oper->read()` single-buffer path, foregoing the readahead optimization but staying correct
- `v1f_rxbuf_read()` (added by the first commit) used raw `read()` and `VTCP_Assert()` directly and unconditionally -- a real bug, since it's used for every chunked-body read regardless of connection type, not just the optional readahead path. Routed it through `htc->oper->read()`/`VCO_Assert()` instead, with a local test-only vco stub added for the `TEST_DRIVER` unit test (which isn't linked against `cache_conn_oper.c`)

Also fixed an unrelated missed vinyl/varnish rename in `bin/vinyld/Makefile.am`: the new `http1_vfp_test`'s `LDADD` referenced the nonexistent `libvinyl.la` instead of `libvarnish.la`.

Upstream:
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/35131b54ead9a9444b181451780bfbc561464577
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/29426f5ef02a7493ee1e06dd14596c5565e2ee03
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/76c9ab1beb973d5512bb874c6b5a7b840ccecf63
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/a4d92bc35cc854223eab8df2f7489d2e8b94a7b7
- https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/commit/0396fb1bc1602654cdebeb6659989364f3ebeba8