### PR TITLE
Port 122d9b0246

### DIFF
--- a/bin/vinyld/mgt/mgt_param.c
+++ b/bin/vinyld/mgt/mgt_param.c
@@ -1028,7 +1028,7 @@ MCF_DumpJsonParam(void)
 			MCF_DYN_FLAGS(TYPE_TIMEOUT, "timeout");
 			MCF_DYN_FLAGS(DELAYED_EFFECT, "delayed");
 			MCF_DYN_FLAGS(MUST_RESTART, "must_restart");
-			MCF_DYN_FLAGS(MUST_RELOAD, "smust_reload");
+			MCF_DYN_FLAGS(MUST_RELOAD, "must_reload");
 			MCF_DYN_FLAGS(EXPERIMENTAL, "experimental");
 			MCF_DYN_FLAGS(WIZARD, "wizard");
 			MCF_DYN_FLAGS(ONLY_ROOT, "only_root");

--- a/bin/vinyltest/tests/u00024.vtc
+++ b/bin/vinyltest/tests/u00024.vtc
@@ -20,6 +20,8 @@ shell {
 		.auto_restart.units == "bool" or error("auto_restart: wrong units"),
 		.auto_restart.default == "on" or error("auto_restart: wrong default"),
 		(.auto_restart | has("minimum")) == false or error("auto_restart: unexpected minimum"),
-		(.auto_restart | has("flags")) == false or error("auto_restart: unexpected flags")
+		(.auto_restart | has("flags")) == false or error("auto_restart: unexpected flags"),
+
+		(.cc_command.flags | index("must_reload")) != null or error("cc_command: missing must_reload flag")
 	' result.json
 }


### PR DESCRIPTION
Fix typo in `must_reload` output in vinyld -x — removes a prepended `s` from the `-x parameter-json` output (`smust_reload` -> `must_reload`).