### PR TITLE
Port 80a60461c6-bbe34f38ad (leftover sweep)

### DIFF
--- a/bin/vinyltest/flint.sh
+++ b/bin/vinyltest/flint.sh
@@ -11,4 +11,5 @@ FLOPS="
 	-I../../lib/libvgz
 	-Ivtest2/lib
 	$(ls vtest2/src/*.c| grep -v /teken.)
+	vtc_varnish.c
 " ../../tools/flint_skel.sh

--- a/bin/vinyltest/vtc_varnish.c
+++ b/bin/vinyltest/vtc_varnish.c
@@ -304,11 +304,21 @@ varnishlog_thread(void *priv)
 				vtc_log(v->vl, 4, "vsl| %10ju %-15s %c [%s]",
 				    (uintmax_t)vxid, tagname, type,
 				    VSB_data(vsb) + 2);
-			} else {
-				vtc_log(v->vl, 4, "vsl| %10ju %-15s %c %.*s",
-				    (uintmax_t)vxid, tagname, type, (int)len,
-				    data);
+				continue;
 			}
+			if (VSL_tagflags[tag] & SLT_F_UNSAFE) {
+				// remove trailing NUL
+				if (len > 1 && data[len - 1] == '\0')
+					len--;
+				VSB_clear(vsb);
+				VSB_quote(vsb, data, len, VSB_QUOTE_ESCHEX);
+				AZ(VSB_finish(vsb));
+				data = VSB_data(vsb);
+				len = VSB_len(vsb);
+			}
+			vtc_log(v->vl, 4, "vsl| %10ju %-15s %c %.*s",
+			    (uintmax_t)vxid, tagname, type, (int)len,
+			    data);
 		}
 		if (i == 0) {
 			/* Nothing to do but wait */

--- a/bin/vinyltest/vtc_varnish.c
+++ b/bin/vinyltest/vtc_varnish.c
@@ -248,13 +248,16 @@ varnishlog_thread(void *priv)
 	unsigned len, vs;
 	const char *tagname, *data;
 	int type, i, opt;
-	struct vsb *vsb = NULL;
+	struct vsb *vsb;
 
 	CAST_OBJ_NOTNULL(v, priv, VARNISH_MAGIC);
 
 	vsl = VSL_New();
 	AN(vsl);
 	vsm = v->vsm_vsl;
+
+	vsb = VSB_new_auto();
+	AN(vsb);
 
 	c = NULL;
 	opt = 0;
@@ -294,8 +297,6 @@ varnishlog_thread(void *priv)
 			data = VSL_CDATA(c->rec.ptr);
 			v->vsl_tag_count[tag]++;
 			if (VSL_tagflags[tag] & SLT_F_BINARY) {
-				if (vsb == NULL)
-					vsb = VSB_new_auto();
 				VSB_clear(vsb);
 				VSB_quote(vsb, data, len, VSB_QUOTE_HEX);
 				AZ(VSB_finish(vsb));
@@ -331,8 +332,7 @@ varnishlog_thread(void *priv)
 	if (c)
 		VSL_DeleteCursor(c);
 	VSL_Delete(vsl);
-	if (vsb != NULL)
-		VSB_destroy(&vsb);
+	VSB_destroy(&vsb);
 
 	return (NULL);
 }


### PR DESCRIPTION
Small leftover fixes found while re-verifying blocks 31-77 of the tail-commit tracking doc, all originally applied by upstream to `vtc_vinyl.c` (this repo's uncompiled duplicate) rather than `vtc_varnish.c` (the one actually compiled, see `VTEST_WITH_VTC_VARNISH`):

- flexelint now covers `vtc_varnish.c` (adapted from upstream's exclude-vtc_varnish/include-vtc_vinyl pair, reversed for our naming)
- `vtc_varnish.c`: always allocate a vsb up front instead of lazily
- `vtc_varnish.c`: respect `SLT_F_UNSAFE`, escaping unprintable characters in vsl output