### PR TITLE
Port 4196617a18-bbe34f38ad

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS += --with-unwind
 endif
 
 install-data-local:
-	$(install_sh) -d -m 0755 "${VARNISH_STATE_DIR}"
+	$(install_sh) -d -m 0755 "$(DESTDIR)/${VARNISH_STATE_DIR}"
 
 distclean-local:
 	-find . '(' -name '*.gcda' -o -name '*.gcda' ')' -exec rm '{}' ';'

--- a/bin/vinyld/mgt/mgt_param.c
+++ b/bin/vinyld/mgt/mgt_param.c
@@ -1028,7 +1028,7 @@ MCF_DumpJsonParam(void)
 			MCF_DYN_FLAGS(TYPE_TIMEOUT, "timeout");
 			MCF_DYN_FLAGS(DELAYED_EFFECT, "delayed");
 			MCF_DYN_FLAGS(MUST_RESTART, "must_restart");
-			MCF_DYN_FLAGS(MUST_RELOAD, "smust_reload");
+			MCF_DYN_FLAGS(MUST_RELOAD, "must_reload");
 			MCF_DYN_FLAGS(EXPERIMENTAL, "experimental");
 			MCF_DYN_FLAGS(WIZARD, "wizard");
 			MCF_DYN_FLAGS(ONLY_ROOT, "only_root");

--- a/bin/vinyltest/flint.sh
+++ b/bin/vinyltest/flint.sh
@@ -11,4 +11,5 @@ FLOPS="
 	-I../../lib/libvgz
 	-Ivtest2/lib
 	$(ls vtest2/src/*.c| grep -v /teken.)
+	vtc_varnish.c
 " ../../tools/flint_skel.sh

--- a/bin/vinyltest/tests/c00146.vtc
+++ b/bin/vinyltest/tests/c00146.vtc
@@ -1,0 +1,27 @@
+vtest "Chunked stress"
+
+server s0 {
+	rxreq
+	txresp -nolen -hdr "Transfer-Encoding: chunked"
+	loop 1024 {
+		chunkedlen 64
+	}
+	chunkedlen 0
+} -dispatch
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pass);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -start
+client c2 {
+	txreq
+	rxresp
+} -start
+client c1 -wait
+client c2 -wait

--- a/bin/vinyltest/tests/u00024.vtc
+++ b/bin/vinyltest/tests/u00024.vtc
@@ -20,6 +20,8 @@ shell {
 		.auto_restart.units == "bool" or error("auto_restart: wrong units"),
 		.auto_restart.default == "on" or error("auto_restart: wrong default"),
 		(.auto_restart | has("minimum")) == false or error("auto_restart: unexpected minimum"),
-		(.auto_restart | has("flags")) == false or error("auto_restart: unexpected flags")
+		(.auto_restart | has("flags")) == false or error("auto_restart: unexpected flags"),
+
+		(.cc_command.flags | index("must_reload")) != null or error("cc_command: missing must_reload flag")
 	' result.json
 }

--- a/bin/vinyltest/vtc_varnish.c
+++ b/bin/vinyltest/vtc_varnish.c
@@ -304,11 +304,21 @@ varnishlog_thread(void *priv)
 				vtc_log(v->vl, 4, "vsl| %10ju %-15s %c [%s]",
 				    (uintmax_t)vxid, tagname, type,
 				    VSB_data(vsb) + 2);
-			} else {
-				vtc_log(v->vl, 4, "vsl| %10ju %-15s %c %.*s",
-				    (uintmax_t)vxid, tagname, type, (int)len,
-				    data);
+				continue;
 			}
+			if (VSL_tagflags[tag] & SLT_F_UNSAFE) {
+				// remove trailing NUL
+				if (len > 1 && data[len - 1] == '\0')
+					len--;
+				VSB_clear(vsb);
+				VSB_quote(vsb, data, len, VSB_QUOTE_ESCHEX);
+				AZ(VSB_finish(vsb));
+				data = VSB_data(vsb);
+				len = VSB_len(vsb);
+			}
+			vtc_log(v->vl, 4, "vsl| %10ju %-15s %c %.*s",
+			    (uintmax_t)vxid, tagname, type, (int)len,
+			    data);
 		}
 		if (i == 0) {
 			/* Nothing to do but wait */

--- a/bin/vinyltest/vtc_varnish.c
+++ b/bin/vinyltest/vtc_varnish.c
@@ -248,13 +248,16 @@ varnishlog_thread(void *priv)
 	unsigned len, vs;
 	const char *tagname, *data;
 	int type, i, opt;
-	struct vsb *vsb = NULL;
+	struct vsb *vsb;
 
 	CAST_OBJ_NOTNULL(v, priv, VARNISH_MAGIC);
 
 	vsl = VSL_New();
 	AN(vsl);
 	vsm = v->vsm_vsl;
+
+	vsb = VSB_new_auto();
+	AN(vsb);
 
 	c = NULL;
 	opt = 0;
@@ -294,8 +297,6 @@ varnishlog_thread(void *priv)
 			data = VSL_CDATA(c->rec.ptr);
 			v->vsl_tag_count[tag]++;
 			if (VSL_tagflags[tag] & SLT_F_BINARY) {
-				if (vsb == NULL)
-					vsb = VSB_new_auto();
 				VSB_clear(vsb);
 				VSB_quote(vsb, data, len, VSB_QUOTE_HEX);
 				AZ(VSB_finish(vsb));
@@ -331,8 +332,7 @@ varnishlog_thread(void *priv)
 	if (c)
 		VSL_DeleteCursor(c);
 	VSL_Delete(vsl);
-	if (vsb != NULL)
-		VSB_destroy(&vsb);
+	VSB_destroy(&vsb);
 
 	return (NULL);
 }

--- a/tools/vtest.sh
+++ b/tools/vtest.sh
@@ -37,7 +37,7 @@ export MAKEFLAGS="${MAKEFLAGS:--j2}"
 
 # This temp directory must not be used by anything else.
 # Do *NOT* set this to /tmp
-export TMPDIR="${TMPDIR:-`pwd`/_vtest_tmp}"
+export TMPDIR="${TMPDIR:-`pwd`}/_vtest_tmp"
 
 # Message to be shown in result pages
 # Max 10 char of [A-Za-z0-9/. _-]


### PR DESCRIPTION
Batch of the remaining real gaps found while re-verifying the vinyl-cache tail-commit tracking doc (closes/supersedes #128 and #129), 7 commits in chronological order:

- `Fix DESTDIR builds` -- adapted to keep `VARNISH_STATE_DIR`
- `Safer TMPDIR`
- `Test backend response with many small chunks` -- new test placed at `c00146.vtc` since `c00139` is already taken by an unrelated test here
- `flint.sh: Lint vtc_varnish.c` -- adapted for this repo's reversed compiled/uncompiled file naming (folds 2 upstream commits)
- `Fix typo in must_reload output in vinyld -x`
- `vtc_varnish: minor simplification: always get a vsb` -- retargeted from `vtc_vinyl.c` (dead duplicate here) to `vtc_varnish.c` (actually compiled)
- `vtc_varnish: consider SLT_F_UNSAFE` -- same retargeting